### PR TITLE
modelCommand

### DIFF
--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -258,19 +258,8 @@ context is a dict with helm root context plus:
   {{- with .container.imagePullPolicy }}
   imagePullPolicy: {{ . }}
   {{- end }}
-  {{- with .container.command }}
-  command:
-    {{- toYaml . | nindent 2 }}
-  {{- end }}
-  args:
-  {{- if not (default false .Values.scriptedStart) }}
-  - {{ .Values.routing.modelName | quote }}
-  - --port
-  - {{ (include "llm-d-modelservice.vllmPort" .) | quote }}
-  {{- end }}
-  {{- with .container.args }}
-    {{- toYaml . | nindent 2 }}
-  {{- end }}
+  {{- /* handle command and args */}}
+  {{- include "llm-d-modelservice.command" . | nindent 2 }}
   {{- /* insert user's env for this container */}}
   {{- if or .container.env .container.mountModelVolume }}
   env:
@@ -278,23 +267,10 @@ context is a dict with helm root context plus:
   {{- with .container.env }}
     {{- toYaml . | nindent 2 }}
   {{- end }}
-  - name: DP_SIZE
-    value: {{ include "llm-d-modelservice.dataParallelism" .parallelism | quote }}
-  - name: TP_SIZE
-    value: {{ include "llm-d-modelservice.tensorParallelism" .parallelism | quote }}
-  - name: DP_SIZE_LOCAL
-    value: {{ include "llm-d-modelservice.dataLocalParallelism" .parallelism | quote }}
+  {{- (include "llm-d-modelservice.parallelismEnv" .) | nindent 2 }}
   {{- /* insert envs based on what modelArtifact prefix */}}
   {{- if .container.mountModelVolume }}
-  - name: HF_HOME
-    value: /model-cache
-  {{- with .Values.modelArtifacts.authSecretName }}
-  - name: HF_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: {{ . }}
-        key: HF_TOKEN
-  {{- end }}
+  {{- (include "llm-d-modelservice.hfEnv" .) | nindent 2 }}
   {{- end }}
   {{- with .container.livenessProbe }}
   livenessProbe:
@@ -328,3 +304,84 @@ context is a dict with helm root context plus:
   tty: {{ . }}
   {{- end }}
 {{- end }} {{- /* define "llm-d-modelservice.container" */}}
+
+{{- define "llm-d-modelservice.vllmServeModelCommand" -}}
+{{- /* override command and set model and --port arguments */}}
+command: ["vllm", "serve"]
+args:
+  - {{ .Values.routing.modelName | quote }}
+  - --port
+  - {{ (include "llm-d-modelservice.vllmPort" .) | quote }}
+{{- with .container.args }}
+  {{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.vllmServeModelCommand" */}}
+
+{{- define "llm-d-modelservice.imageDefaultModelCommand" -}}
+{{- /* no command needed, set --model and --port arguments */}}
+args:
+  - --model
+  - {{ .Values.routing.modelName | quote }}
+  - --port
+  - {{ (include "llm-d-modelservice.vllmPort" .) | quote }}
+{{- with .container.args }}
+  {{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.imageDefaultModelCommand" */}}
+
+{{- define "llm-d-modelservice.customModelCommand" -}}
+{{- /* use provided command and args (fail if no command) */}}
+{{- if not .container.command }}
+{{- fail "When .container.modelCommand not set or `custom`, a `command` is required." }}
+{{- else }}
+{{- with .container.command }}
+command:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .container.args }}
+args:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.modelCommandCustom" */}}
+
+{{/*
+Container elements of deployment/lws spec template
+context is a dict with helm root context plus:
+   key - "container"; value - container spec
+   key - "roll"; value - either "decode" or "prefill"
+   key - "parallelism"; value - $.Values.decode.parallelism
+*/}}
+{{- define "llm-d-modelservice.command" -}}
+{{- $modelCommand := default "custom" .container.modelCommand -}}
+{{- if eq $modelCommand "vllmServe" }}
+{{- include "llm-d-modelservice.vllmServeModelCommand" . }}
+{{- else if eq $modelCommand "imageDefault" }}
+{{- include "llm-d-modelservice.imageDefaultModelCommand" . }}
+{{- else if eq $modelCommand "custom" }}
+{{- include "llm-d-modelservice.customModelCommand" . }}
+{{- else }}
+{{- fail ".container.modelCommand is not as expected. Valid values are `vllmServe`, `imageDefault` and `custom`." }}
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.command" */}}
+
+{{- define "llm-d-modelservice.hfEnv" -}}
+- name: HF_HOME
+  value: /model-cache
+{{- with .Values.modelArtifacts.authSecretName }}
+- name: HF_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ . }}
+      key: HF_TOKEN
+{{- end }}
+{{- end }} {{- /* define "llm-d-modelservice.hfEnv" */}}
+
+{{- define "llm-d-modelservice.parallelismEnv" -}}
+- name: DP_SIZE
+  value: {{ include "llm-d-modelservice.dataParallelism" .parallelism | quote }}
+- name: TP_SIZE
+  value: {{ include "llm-d-modelservice.tensorParallelism" .parallelism | quote }}
+- name: DP_SIZE_LOCAL
+  value: {{ include "llm-d-modelservice.dataLocalParallelism" .parallelism | quote }}
+{{- end }} {{- /* define "llm-d-modelservice.pvcEnv" */}}

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -28,11 +28,7 @@ decode:
   containers:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d-inference-sim:0.0.4"
-    args:
-      - "--model"
-      - "random"
-      - "--port"
-      - "8200"  # targetPort
+    modelCommand: imageDefault
     ports:
       - containerPort: 5557
         protocol: TCP
@@ -42,11 +38,7 @@ prefill:
   containers:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d-inference-sim:0.0.4"
-    args:
-      - "--model"
-      - "random"
-      - "--port"
-      - "8000"  # servicePort
+    modelCommand: imageDefault
     ports:
       - containerPort: 5557
         protocol: TCP

--- a/examples/values-facebook.yaml
+++ b/examples/values-facebook.yaml
@@ -26,9 +26,7 @@ decode:
   containers:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d:0.0.8"
-    command:
-      - vllm
-      - serve
+    modelCommand: vllmServe
     args:
       - "--enforce-eager"
       - "--kv-transfer-config"
@@ -38,8 +36,6 @@ decode:
         value: "0"
       - name: UCX_TLS
         value: "cuda_ipc,cuda_copy,tcp"
-      - name: HF_HOME
-        value: /model-cache
       - name: VLLM_NIXL_SIDE_CHANNEL_HOST
         valueFrom:
           fieldRef:
@@ -68,9 +64,7 @@ prefill:
   containers:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d:0.0.8"
-    command:
-      - vllm
-      - serve
+    modelCommand: vllmServe
     args:
       - "--enforce-eager"
       - "--kv-transfer-config"

--- a/examples/values-qwen-lws.yaml
+++ b/examples/values-qwen-lws.yaml
@@ -66,6 +66,7 @@ decode:
       workingDir: /code
       stdin: true
       tty: true
+      modelCommand: custom
       command: ["/bin/sh","-c"]
       args:
         - |
@@ -257,6 +258,7 @@ prefill:
       workingDir: /code
       stdin: true
       tty: true
+      modelCommand: custom
       command: ["/bin/sh","-c"]
       args:
         - |

--- a/examples/values-vllm-sim.yaml
+++ b/examples/values-vllm-sim.yaml
@@ -27,11 +27,7 @@ decode:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d-inference-sim:0.0.4"
     modelCommand: imageDefault
-    args:
-      - "--model"
-      - "random"
-      - "--port"
-      - "8200"  # targetPort
+
     ports:
       - containerPort: 5557
         protocol: TCP
@@ -42,11 +38,7 @@ prefill:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d-inference-sim:0.0.4"
     modelCommand: imageDefault
-    args:
-      - "--model"
-      - "random"
-      - "--port"
-      - "8000"  # servicePort
+
     ports:
       - containerPort: 5557
         protocol: TCP

--- a/examples/values-vllm-sim.yaml
+++ b/examples/values-vllm-sim.yaml
@@ -6,7 +6,7 @@ httpRoute: true
 
 routing:
   # This is the model name for the OpenAI request
-  modelName: mk/modelid
+  modelName: random
   servicePort: 8000   # Sidecar listens on this port for requests. If there's no sidecar, the request goes here
   proxy:
     image: ghcr.io/llm-d/llm-d-routing-sidecar:0.0.6
@@ -17,7 +17,7 @@ routing:
     name: inference-gateway
 
 modelArtifacts:
-  uri: "hf://mk/modelid"
+  uri: "hf://random"
   size: 5Mi
 
 # describe decode pods
@@ -26,9 +26,10 @@ decode:
   containers:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d-inference-sim:0.0.4"
+    modelCommand: imageDefault
     args:
       - "--model"
-      - "mk/modelid"
+      - "random"
       - "--port"
       - "8200"  # targetPort
     ports:
@@ -40,9 +41,10 @@ prefill:
   containers:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d-inference-sim:0.0.4"
+    modelCommand: imageDefault
     args:
       - "--model"
-      - "mk/modelid"
+      - "random"
       - "--port"
       - "8000"  # servicePort
     ports:


### PR DESCRIPTION
**`modelCommand`**
Adds `modelCommand` to `decode.containers` and `prefill.containers`. This addresses the second item in issue https://github.com/llm-d-incubation/llm-d-modelservice/issues/10.

There are three acceptable values:
    - `vllmServe`: the command `["vllm", "serve"]` will be added as will arguments for model and port.
    - `imageDefault`: the container default will be used; no `command` is specified. Arguments for model and port will be added.
    - `custom`: the container must have a `command` that will be used. Further, all arguments are used as is (none are added).

In add cases, environment variables for `HF_TOKEN`, `HF_HOME`, `DP_SIZE`, `TP_SIZE`, `DP_SIZE_LOCAL` may be set.

**`--model` argument**
Correctly sets first argument for `modelService: vllmServe` to be either the model (when artifact is `hf://` or the path to the model (when artifact is `pvc://`).  Adds the `--model` argument when using the `modelService: imageDefault`. This addresses the third item in issue https://github.com/llm-d-incubation/llm-d-modelservice/issues/10.