### PR TITLE
enable upstream GAIE charts

### DIFF
--- a/charts/llm-d-modelservice/templates/decode-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/decode-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.decode (not .Values.multinode) }}
+{{- if and .Values.decode.create (not .Values.multinode) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/llm-d-modelservice/templates/decode-lws.yaml
+++ b/charts/llm-d-modelservice/templates/decode-lws.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.decode .Values.multinode }}
+{{- if and .Values.decode.create .Values.multinode }}
 apiVersion: leaderworkerset.x-k8s.io/v1
 kind: LeaderWorkerSet
 metadata:

--- a/charts/llm-d-modelservice/templates/epp-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/epp-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.endpointPicker -}}
+{{- if .Values.endpointPicker.create }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/llm-d-modelservice/templates/epp-role.yaml
+++ b/charts/llm-d-modelservice/templates/epp-role.yaml
@@ -1,12 +1,13 @@
-{{- if .Values.endpointPicker -}}
+{{- if and .Values.endpointPicker.create .Values.endpointPicker.role.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-epp-role
+  name: default-epp-role
 rules:
 - apiGroups:
   - inference.networking.x-k8s.io
   resources:
+  - inferencepools
   - inferencemodels
   verbs:
   - get
@@ -16,14 +17,6 @@ rules:
   - ""
   resources:
   - pods
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - inference.networking.x-k8s.io
-  resources:
-  - inferencepools
   verbs:
   - get
   - watch

--- a/charts/llm-d-modelservice/templates/epp-rolebinding.yaml
+++ b/charts/llm-d-modelservice/templates/epp-rolebinding.yaml
@@ -1,16 +1,12 @@
-{{- if .Values.endpointPicker -}}
+{{- if and .Values.endpointPicker.create .Values.endpointPicker.role.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-epp-rolebinding
+  name: {{ .Values.endpointPicker.role.name | default "default-epp-rolebinding" }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  {{- if .Values.endpointPicker.permissions }}
-  name: {{ .Values.endpointPicker.permissions }}
-  {{- else }}
-  name: {{ include "llm-d-modelservice.fullname" . }}-epp-role
-  {{- end }}
+  name: {{ .Values.endpointPicker.role.name | default "default-epp-role" }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "llm-d-modelservice.eppServiceAccountName" . }}

--- a/charts/llm-d-modelservice/templates/epp-sa.yaml
+++ b/charts/llm-d-modelservice/templates/epp-sa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.endpointPicker -}}
+{{- if .Values.endpointPicker.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/llm-d-modelservice/templates/epp-service.yaml
+++ b/charts/llm-d-modelservice/templates/epp-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.endpointPicker -}}
+{{- if .Values.endpointPicker.create }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,4 +14,4 @@ spec:
       appProtocol: {{ .Values.endpointPicker.service.appProtocol }}
   selector:
     llm-d.ai/epp: {{ include "llm-d-modelservice.fullname" . }}-epp
-{{- end }}
+{{- end}}

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -2,6 +2,7 @@
 
 # This values.yaml file creates the resources for random
 
+<<<<<<< HEAD
 # When true, LeaderWorkerSet is used instead of Deployment
 multinode: false
 # When true, an InferencePool is created.
@@ -12,6 +13,16 @@ inferencePool: true
 # When false, an HTTPRoute is not created.
 # Note that when inferencePool is false, or there is is no endpointPicker, the HTTPRoute is not created (overriding a true here).
 httpRoute: true
+=======
+multinode: 
+  create: false
+
+httpRoute: 
+  # When true, an HTTPRoute is created.
+  # When false, an HTTPRoute is not created.
+  # Note that when inferencePool is false, or there is is no endpointPicker, the HTTPRoute is not created (overriding a true here).
+  create: true
+>>>>>>> e5681de (enable upstream GAIE charts)
 
 # To control creation of the endpoint picker (inference scheduler), see endpointPicker below
 
@@ -27,12 +38,14 @@ routing:
     kind: Gateway
     name: llm-d-inference-gateway
 
+
 modelArtifacts:
   uri: "hf://random/modelid"
   size: 5Mi
 
 # describe decode pods
 decode:
+  create: true
   replicas: 1
   containers:
   - name: "vllm"
@@ -43,6 +56,7 @@ decode:
         protocol: TCP
     mountModelVolume: true
 prefill:
+  create: true
   replicas: 1
   containers:
   - name: "vllm"
@@ -53,6 +67,7 @@ prefill:
         protocol: TCP
     mountModelVolume: true
 
+<<<<<<< HEAD
 # When endpointPicker is present, create the endpoint picker (inference scheduler) objects:
 # ServiceAccount, Role, Rolebinding, Deployment, Service
 # When endpointPicker is not present, these objects are not created.
@@ -71,3 +86,25 @@ prefill:
 #   replicas: 1
 #   # To use a different role from the default, provide the name of the role
 #   # permissions: pod-read
+=======
+endpointPicker:
+  create: true
+  # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+  service:
+    # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    type: ClusterIP
+    # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+    port: 9002
+    targetPort: 9002
+    appProtocol: http2
+  debugLevel: 6
+  disableReadinessProbe: true
+  disableLivenessProbe: true
+  replicas: 1
+  role:
+    name: default-epp-role
+    create: true
+
+inferencePool:
+  create: true
+>>>>>>> e5681de (enable upstream GAIE charts)


### PR DESCRIPTION
cc @kalantar 

Can look at this after I review your PR.

Changes:
- move to `component.create` pattern, so that other values can be tracked under the component
- creating decode and prefill services, this will help enable the servicemonitor and metrics story
- All EPP manifests need to be disable-able to use upstream GAIE charts
- Creating a static `default-epp-role` which may go unused and swapped with whatever pre-created role desired, as per the previous pattern in this repo