### PR TITLE
Limit extensions to names

### DIFF
--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -7,24 +7,26 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 55 chars because some Kubernetes name fields are limited to 63 (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
+We use 55 because we add up to 8 characters (`-prefill`)
 */}}
 {{- define "llm-d-modelservice.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Values.fullnameOverride | trunc 55 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- .Release.Name | trunc 55 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Release.Name $name | trunc 55 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
+Truncated to 63 characrters because Kubernetes label values are limited to this
 */}}
 {{- define "llm-d-modelservice.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
@@ -157,17 +159,54 @@ resources:
     {{- toYaml $requests | nindent 4 }}
 {{- end }}
 
-{{/* P/D service account name */}}
-{{- define "llm-d-modelservice.pdServiceAccountName" -}}
-{{ include "llm-d-modelservice.fullname" . }}-sa
+{{/* EPP name */}}
+{{- define "llm-d-modelservice.eppName" -}}
+{{ include "llm-d-modelservice.fullname" . }}-epp
 {{- end }}
 
-{{/* 
-EPP service account name 
-Context is helm root context
-*/}}
+{{/* prefill name */}}
+{{- define "llm-d-modelservice.prefillName" -}}
+{{ include "llm-d-modelservice.fullname" . }}-prefill
+{{- end }}
+
+{{/* decode name */}}
+{{- define "llm-d-modelservice.decodeName" -}}
+{{ include "llm-d-modelservice.fullname" . }}-decode
+{{- end }}
+
+{{/* P/D service account name */}}
+{{- define "llm-d-modelservice.pdServiceAccountName" -}}
+{{ include "llm-d-modelservice.fullname" . }}
+{{- end }}
+
+{{/* EPP service account name */}}
 {{- define "llm-d-modelservice.eppServiceAccountName" -}}
-{{ include "llm-d-modelservice.fullname" . }}-epp-sa
+{{ include "llm-d-modelservice.eppName" . }}
+{{- end }}
+
+{{/* EPP service name */}}
+{{- define "llm-d-modelservice.eppServiceName" -}}
+{{ include "llm-d-modelservice.eppName" . }}
+{{- end }}
+
+{{/* EPP role name */}}
+{{- define "llm-d-modelservice.eppRoleName" -}}
+{{ include "llm-d-modelservice.eppName" . }}
+{{- end }}
+
+{{/* EPP rolebinding name */}}
+{{- define "llm-d-modelservice.eppRoleBindingName" -}}
+{{ include "llm-d-modelservice.eppName" . }}
+{{- end }}
+
+{{/* default inference pool name */}}
+{{- define "llm-d-modelservice.inferencePoolName" -}}
+{{ include "llm-d-modelservice.fullname" . }}
+{{- end }}
+
+{{/* default http route name */}}
+{{- define "llm-d-modelservice.httpRouteName" -}}
+{{ include "llm-d-modelservice.fullname" . }}
 {{- end }}
 
 {{/*

--- a/charts/llm-d-modelservice/templates/decode-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/decode-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-decode
+  name: {{ include "llm-d-modelservice.decodeName" . }}
   labels:
     {{- include "llm-d-modelservice.labels" . | nindent 4 }}
 spec:

--- a/charts/llm-d-modelservice/templates/decode-lws.yaml
+++ b/charts/llm-d-modelservice/templates/decode-lws.yaml
@@ -2,7 +2,7 @@
 apiVersion: leaderworkerset.x-k8s.io/v1
 kind: LeaderWorkerSet
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-decode
+  name: {{ include "llm-d-modelservice.decodeName" . }}
   labels:
     {{- include "llm-d-modelservice.labels" . | nindent 4 }}
     {{- include "llm-d-modelservice.decodelabels" . | nindent 4 }}

--- a/charts/llm-d-modelservice/templates/epp-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/epp-deployment.yaml
@@ -2,19 +2,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-epp
+  name: {{ include "llm-d-modelservice.eppName" . }}
   labels:
-    llm-d.ai/epp: {{ include "llm-d-modelservice.fullname" . }}-epp
+    llm-d.ai/epp: {{ include "llm-d-modelservice.eppName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ default 1 .Values.routing.epp.replicas }}
   selector:
     matchLabels:
-      llm-d.ai/epp: {{ include "llm-d-modelservice.fullname" . }}-epp
+      llm-d.ai/epp: {{ include "llm-d-modelservice.eppName" . }}
   template:
     metadata:
       labels:
-        llm-d.ai/epp: {{ include "llm-d-modelservice.fullname" . }}-epp
+        llm-d.ai/epp: {{ include "llm-d-modelservice.eppName" . }}
     spec:
       containers:
       - name: epp

--- a/charts/llm-d-modelservice/templates/epp-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/epp-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- if .Values.routing.epp.inferencePool }}
         - {{ .Values.routing.epp.inferencePool }}
         {{- else }}
-        - {{ include "llm-d-modelservice.fullname" . }}-inference-pool
+        - {{ include "llm-d-modelservice.inferencePoolName" . }}
         {{- end }}
         - --poolNamespace
         - {{ .Release.Namespace }}

--- a/charts/llm-d-modelservice/templates/epp-role.yaml
+++ b/charts/llm-d-modelservice/templates/epp-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-epp-role
+  name: {{ include "llm-d-modelservice.eppRoleName" . }}
 rules:
 - apiGroups:
   - inference.networking.x-k8s.io

--- a/charts/llm-d-modelservice/templates/epp-rolebinding.yaml
+++ b/charts/llm-d-modelservice/templates/epp-rolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-epp-rolebinding
+  name: {{ include "llm-d-modelservice.eppRoleBindingName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/llm-d-modelservice/templates/epp-rolebinding.yaml
+++ b/charts/llm-d-modelservice/templates/epp-rolebinding.yaml
@@ -9,7 +9,7 @@ roleRef:
   {{- if .Values.routing.epp.permissions }}
   name: {{ .Values.routing.epp.permissions }}
   {{- else }}
-  name: {{ include "llm-d-modelservice.fullname" . }}-epp-role
+  name: {{ include "llm-d-modelservice.eppRoleName" . }}
   {{- end }}
 subjects:
 - kind: ServiceAccount

--- a/charts/llm-d-modelservice/templates/epp-service.yaml
+++ b/charts/llm-d-modelservice/templates/epp-service.yaml
@@ -13,5 +13,5 @@ spec:
       protocol: TCP
       appProtocol: {{ .Values.routing.epp.service.appProtocol }}
   selector:
-    llm-d.ai/epp: {{ include "llm-d-modelservice.fullname" . }}-epp
+    llm-d.ai/epp: {{ include "llm-d-modelservice.eppName" . }}
 {{- end }}

--- a/charts/llm-d-modelservice/templates/epp-service.yaml
+++ b/charts/llm-d-modelservice/templates/epp-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-epp-service
+  name: {{ include "llm-d-modelservice.eppServiceName" . }}
   labels:
     {{- include "llm-d-modelservice.labels" . | nindent 4 }}
 spec:

--- a/charts/llm-d-modelservice/templates/httproute.yaml
+++ b/charts/llm-d-modelservice/templates/httproute.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-http-route
+  name: {{ include "llm-d-modelservice.httpRouteName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "llm-d-modelservice.labels" . | nindent 4 }}
@@ -24,7 +24,7 @@ spec:
       {{- if .Values.routing.httpRoute.inferencePool }}
       name: {{ .Values.routing.httpRoute.inferencePool }}
       {{- else }}
-      name: {{ include "llm-d-modelservice.fullname" . }}-inference-pool
+      name: {{ include "llm-d-modelservice.inferencePoolName" . }}
       {{- end }}
       port: {{ .Values.routing.servicePort  }}
       weight: 1

--- a/charts/llm-d-modelservice/templates/httproute.yaml
+++ b/charts/llm-d-modelservice/templates/httproute.yaml
@@ -38,10 +38,6 @@ spec:
     - path:
         type: PathPrefix
         value: /
-      headers:
-      - name: x-model-name
-        type: Exact
-        value: {{ .Values.routing.modelName }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/llm-d-modelservice/templates/inferencepool.yaml
+++ b/charts/llm-d-modelservice/templates/inferencepool.yaml
@@ -2,7 +2,7 @@
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-inference-pool
+  name: {{ include "llm-d-modelservice.inferencePoolName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   extensionRef:
@@ -12,7 +12,7 @@ spec:
     {{- if .Values.routing.inferencePool.extensionRef }}
     name: {{ .Values.routing.inferencePool.extensionRef }}
     {{- else }}
-    name: {{ include "llm-d-modelservice.fullname" . }}-epp-service
+    name: {{ include "llm-d-modelservice.eppServiceName" . }}
     {{- end }}
   selector:
     {{- if .Values.multinode }}

--- a/charts/llm-d-modelservice/templates/prefill-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/prefill-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-prefill
+  name: {{ include "llm-d-modelservice.prefillName" . }}
   labels:
     {{- include "llm-d-modelservice.labels" . | nindent 4 }}
 spec:

--- a/charts/llm-d-modelservice/templates/prefill-lws.yaml
+++ b/charts/llm-d-modelservice/templates/prefill-lws.yaml
@@ -2,7 +2,7 @@
 apiVersion: leaderworkerset.x-k8s.io/v1
 kind: LeaderWorkerSet
 metadata:
-  name: {{ include "llm-d-modelservice.fullname" . }}-prefill
+  name: {{ include "llm-d-modelservice.prefillName" . }}
   labels:
     {{- include "llm-d-modelservice.labels" . | nindent 4 }}
     {{- include "llm-d-modelservice.prefilllabels" . | nindent 4 }}

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -52,7 +52,10 @@ routing:
     # backendRefs:
     # to override matches defined for the single inferece pool created (when `routing.httpRoute.create: true`)`
     # Note that this is ignored if `backendRefs` is set (in which case it must be defined as a child to each backendRef)
-    # matches:
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
 
   # Configuration of EPP (endpoint picker)
   # cf. https://github.com/llm-d/llm-d-inference-scheduler

--- a/examples/output-facebook.yaml
+++ b/examples/output-facebook.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: facebook-llm-d-modelservice-epp-sa
+  name: facebook-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -13,9 +13,9 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: facebook-llm-d-modelservice-sa
+  name: facebook-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -23,7 +23,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: facebook-llm-d-modelservice-epp-role
+  name: facebook-llm-d-modelservice-epp
 rules:
 - apiGroups:
   - inference.networking.x-k8s.io
@@ -67,22 +67,22 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: facebook-llm-d-modelservice-epp-rolebinding
+  name: facebook-llm-d-modelservice-epp
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: facebook-llm-d-modelservice-epp-role
+  name: facebook-llm-d-modelservice-epp
 subjects:
 - kind: ServiceAccount
-  name: facebook-llm-d-modelservice-epp-sa
+  name: facebook-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/epp-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: facebook-llm-d-modelservice-epp-service
+  name: facebook-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -101,7 +101,7 @@ kind: Deployment
 metadata:
   name: facebook-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -135,7 +135,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
     
-      serviceAccountName: facebook-llm-d-modelservice-sa
+      serviceAccountName: facebook-llm-d-modelservice
       volumes:
         - name: model-storage
           emptyDir: 
@@ -212,7 +212,7 @@ spec:
         image: ghcr.io/llm-d/llm-d-inference-scheduler:0.0.3
         args:
         - --poolName
-        - facebook-llm-d-modelservice-inference-pool
+        - facebook-llm-d-modelservice
         - --poolNamespace
         - e2e-solution
         - -v
@@ -290,8 +290,8 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           failureThreshold: 3
-      serviceAccount: facebook-llm-d-modelservice-epp-sa
-      serviceAccountName: facebook-llm-d-modelservice-epp-sa
+      serviceAccount: facebook-llm-d-modelservice-epp
+      serviceAccountName: facebook-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/prefill-deployment.yaml
 apiVersion: apps/v1
@@ -299,7 +299,7 @@ kind: Deployment
 metadata:
   name: facebook-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -317,7 +317,7 @@ spec:
         llm-d.ai/role: prefill
     spec:
     
-      serviceAccountName: facebook-llm-d-modelservice-sa
+      serviceAccountName: facebook-llm-d-modelservice
       volumes:
         - name: model-storage
           emptyDir: 
@@ -369,10 +369,10 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: facebook-llm-d-modelservice-http-route
+  name: facebook-llm-d-modelservice
   namespace: e2e-solution
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -384,30 +384,30 @@ spec:
   - backendRefs:
     - group: inference.networking.x-k8s.io
       kind: InferencePool
-      name: facebook-llm-d-modelservice-inference-pool
+      name: facebook-llm-d-modelservice
       port: 8000
       weight: 1
     matches:
-    - path:
-        type: PathPrefix
-        value: /
-      headers:
+    - headers:
       - name: x-model-name
         type: Exact
         value: facebook/opt-125m
+      path:
+        type: PathPrefix
+        value: /
 ---
 # Source: llm-d-modelservice/templates/inferencepool.yaml
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
-  name: facebook-llm-d-modelservice-inference-pool
+  name: facebook-llm-d-modelservice
   namespace: e2e-solution
 spec:
   extensionRef:
     failureMode: FailClose
     group: ""
     kind: Service
-    name: facebook-llm-d-modelservice-epp-service
+    name: facebook-llm-d-modelservice-epp
   selector:
     llm-d.ai/inferenceServing: "true"
     llm-d.ai/model: facebook-llm-d-modelservice

--- a/examples/output-qwen-lws.yaml
+++ b/examples/output-qwen-lws.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: qwen-lws-llm-d-modelservice-epp-sa
+  name: qwen-lws-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -13,9 +13,9 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: qwen-lws-llm-d-modelservice-sa
+  name: qwen-lws-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -23,7 +23,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: qwen-lws-llm-d-modelservice-epp-role
+  name: qwen-lws-llm-d-modelservice-epp
 rules:
 - apiGroups:
   - inference.networking.x-k8s.io
@@ -67,22 +67,22 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: qwen-lws-llm-d-modelservice-epp-rolebinding
+  name: qwen-lws-llm-d-modelservice-epp
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: qwen-lws-llm-d-modelservice-epp-role
+  name: qwen-lws-llm-d-modelservice-epp
 subjects:
 - kind: ServiceAccount
-  name: qwen-lws-llm-d-modelservice-epp-sa
+  name: qwen-lws-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/epp-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: qwen-lws-llm-d-modelservice-epp-service
+  name: qwen-lws-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -119,7 +119,7 @@ spec:
         image: ghcr.io/llm-d/llm-d-inference-scheduler:0.0.3
         args:
         - --poolName
-        - qwen-lws-llm-d-modelservice-inference-pool
+        - qwen-lws-llm-d-modelservice
         - --poolNamespace
         - default
         - -v
@@ -197,17 +197,17 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           failureThreshold: 3
-      serviceAccount: qwen-lws-llm-d-modelservice-epp-sa
-      serviceAccountName: qwen-lws-llm-d-modelservice-epp-sa
+      serviceAccount: qwen-lws-llm-d-modelservice-epp
+      serviceAccountName: qwen-lws-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/httproute.yaml
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: qwen-lws-llm-d-modelservice-http-route
+  name: qwen-lws-llm-d-modelservice
   namespace: default
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -219,30 +219,26 @@ spec:
   - backendRefs:
     - group: inference.networking.x-k8s.io
       kind: InferencePool
-      name: qwen-lws-llm-d-modelservice-inference-pool
+      name: qwen-lws-llm-d-modelservice
       port: 8080
       weight: 1
     matches:
     - path:
         type: PathPrefix
         value: /
-      headers:
-      - name: x-model-name
-        type: Exact
-        value: Qwen/Qwen3-30B-A3B-FP8
 ---
 # Source: llm-d-modelservice/templates/inferencepool.yaml
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
-  name: qwen-lws-llm-d-modelservice-inference-pool
+  name: qwen-lws-llm-d-modelservice
   namespace: default
 spec:
   extensionRef:
     failureMode: FailClose
     group: ""
     kind: Service
-    name: qwen-lws-llm-d-modelservice-epp-service
+    name: qwen-lws-llm-d-modelservice-epp
   selector:
     leaderworkerset.sigs.k8s.io/worker-index: "0"
     llm-d.ai/inferenceServing: "true"
@@ -255,7 +251,7 @@ kind: LeaderWorkerSet
 metadata:
   name: qwen-lws-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/inferenceServing: "true"
@@ -290,7 +286,7 @@ spec:
               allowPrivilegeEscalation: false
               runAsNonRoot: true
       
-        serviceAccountName: qwen-lws-llm-d-modelservice-sa
+        serviceAccountName: qwen-lws-llm-d-modelservice
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
@@ -472,7 +468,7 @@ spec:
           llm-d.ai/role: decode
       spec:
       
-        serviceAccountName: qwen-lws-llm-d-modelservice-sa
+        serviceAccountName: qwen-lws-llm-d-modelservice
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
@@ -652,7 +648,7 @@ kind: LeaderWorkerSet
 metadata:
   name: qwen-lws-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/inferenceServing: "true"
@@ -673,7 +669,7 @@ spec:
           llm-d.ai/role: prefill
       spec:
       
-        serviceAccountName: qwen-lws-llm-d-modelservice-sa
+        serviceAccountName: qwen-lws-llm-d-modelservice
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/output-vllm-sim.yaml
+++ b/examples/output-vllm-sim.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vllm-sim-llm-d-modelservice-epp-sa
+  name: vllm-sim-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -13,9 +13,9 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vllm-sim-llm-d-modelservice-sa
+  name: vllm-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -23,7 +23,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: vllm-sim-llm-d-modelservice-epp-role
+  name: vllm-sim-llm-d-modelservice-epp
 rules:
 - apiGroups:
   - inference.networking.x-k8s.io
@@ -67,22 +67,22 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: vllm-sim-llm-d-modelservice-epp-rolebinding
+  name: vllm-sim-llm-d-modelservice-epp
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: vllm-sim-llm-d-modelservice-epp-role
+  name: vllm-sim-llm-d-modelservice-epp
 subjects:
 - kind: ServiceAccount
-  name: vllm-sim-llm-d-modelservice-epp-sa
+  name: vllm-sim-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/epp-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: vllm-sim-llm-d-modelservice-epp-service
+  name: vllm-sim-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -101,7 +101,7 @@ kind: Deployment
 metadata:
   name: vllm-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -135,7 +135,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
     
-      serviceAccountName: vllm-sim-llm-d-modelservice-sa
+      serviceAccountName: vllm-sim-llm-d-modelservice
       volumes:
         - name: model-storage
           emptyDir: 
@@ -192,7 +192,7 @@ spec:
         image: ghcr.io/llm-d/llm-d-inference-scheduler:0.0.3
         args:
         - --poolName
-        - vllm-sim-llm-d-modelservice-inference-pool
+        - vllm-sim-llm-d-modelservice
         - --poolNamespace
         - default
         - -v
@@ -252,8 +252,8 @@ spec:
         - containerPort: 9090
           name: metrics
           protocol: TCP
-      serviceAccount: vllm-sim-llm-d-modelservice-epp-sa
-      serviceAccountName: vllm-sim-llm-d-modelservice-epp-sa
+      serviceAccount: vllm-sim-llm-d-modelservice-epp
+      serviceAccountName: vllm-sim-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/prefill-deployment.yaml
 apiVersion: apps/v1
@@ -261,7 +261,7 @@ kind: Deployment
 metadata:
   name: vllm-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -279,7 +279,7 @@ spec:
         llm-d.ai/role: prefill
     spec:
     
-      serviceAccountName: vllm-sim-llm-d-modelservice-sa
+      serviceAccountName: vllm-sim-llm-d-modelservice
       volumes:
         - name: model-storage
           emptyDir: 
@@ -316,10 +316,10 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: vllm-sim-llm-d-modelservice-http-route
+  name: vllm-sim-llm-d-modelservice
   namespace: default
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.7
+    helm.sh/chart: llm-d-modelservice-0.0.8
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -331,30 +331,30 @@ spec:
   - backendRefs:
     - group: inference.networking.x-k8s.io
       kind: InferencePool
-      name: vllm-sim-llm-d-modelservice-inference-pool
+      name: vllm-sim-llm-d-modelservice
       port: 8000
       weight: 1
     matches:
-    - path:
-        type: PathPrefix
-        value: /
-      headers:
+    - headers:
       - name: x-model-name
         type: Exact
         value: random
+      path:
+        type: PathPrefix
+        value: /
 ---
 # Source: llm-d-modelservice/templates/inferencepool.yaml
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
-  name: vllm-sim-llm-d-modelservice-inference-pool
+  name: vllm-sim-llm-d-modelservice
   namespace: default
 spec:
   extensionRef:
     failureMode: FailClose
     group: ""
     kind: Service
-    name: vllm-sim-llm-d-modelservice-epp-service
+    name: vllm-sim-llm-d-modelservice-epp
   selector:
     llm-d.ai/inferenceServing: "true"
     llm-d.ai/model: vllm-sim-llm-d-modelservice

--- a/examples/values-facebook.yaml
+++ b/examples/values-facebook.yaml
@@ -27,6 +27,14 @@ routing:
 
   httpRoute:
     create: true
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+      headers:
+      - name: x-model-name
+        type: Exact
+        value: facebook/opt-125m
 
   epp:
     create: true

--- a/examples/values-vllm-sim.yaml
+++ b/examples/values-vllm-sim.yaml
@@ -13,6 +13,16 @@ routing:
   modelName: random
   servicePort: 8000
 
+  httpRoute:
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+      headers:
+      - name: x-model-name
+        type: Exact
+        value: random
+
   epp:
     create: true
     debugLevel: 6


### PR DESCRIPTION
1. Remove header from default match in HTTPRoute so is more general. Include header in example value files as override.
2. Limit extensions to fullname to prevent creation of objects with names that are too long.