### PR TITLE
make modelservice compatible with inference-scheduler v0.5.0

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.10
+version: 0.0.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -199,6 +199,11 @@ resources:
 {{ include "llm-d-modelservice.eppName" . }}
 {{- end }}
 
+{{/* EPP Config name */}}
+{{- define "llm-d-modelservice.eppConfigName" -}}
+{{ include "llm-d-modelservice.eppName" . }}
+{{- end }}
+
 {{/* default inference pool name */}}
 {{- define "llm-d-modelservice.inferencePoolName" -}}
 {{- if .Values.routing.inferencePool.name -}}

--- a/charts/llm-d-modelservice/templates/epp-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/epp-deployment.yaml
@@ -33,6 +33,10 @@ spec:
         - "9002"
         - --grpcHealthPort
         - "9003"
+        {{- if .Values.routing.epp.pluginsConfigFile }}
+        - "-configFile"
+        - "/config/{{ .Values.routing.epp.pluginsConfigFile }}"
+        {{- end}}
         {{- with .Values.routing.epp.env }}
         env:
         {{- toYaml . | nindent 8 }}
@@ -69,6 +73,15 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         {{- end }}
+      {{- if .Values.routing.epp.pluginsConfigFile }}
+        volumeMounts:
+          - name: plugins-config-volume
+            mountPath: "/config"
+      volumes:
+      - name: plugins-config-volume
+        configMap:
+          name: {{ include "llm-d-modelservice.eppConfigName" . }}
+      {{- end }}
       serviceAccount: {{ include "llm-d-modelservice.eppServiceAccountName" . }}
       serviceAccountName: {{ include "llm-d-modelservice.eppServiceAccountName" . }}
 {{- end }}

--- a/charts/llm-d-modelservice/templates/epp-plugin-configmap.yaml
+++ b/charts/llm-d-modelservice/templates/epp-plugin-configmap.yaml
@@ -1,0 +1,99 @@
+{{- if and .Values.routing.epp.create .Values.routing.epp.pluginsConfigFile -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "llm-d-modelservice.eppConfigName" . }}
+  namespace: {{ .Release.Namespace }}
+data:
+  default-config.yaml: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+    - type: prefix-cache-scorer
+      parameters:
+        hashBlockSize: 5
+        maxPrefixBlocksToMatch: 256
+        lruCapacityPerServer: 31250
+    - type: decode-filter
+    - type: max-score-picker
+    - type: single-profile-handler
+    schedulingProfiles:
+    - name: default
+      plugins:
+      - pluginRef: decode-filter
+      - pluginRef: max-score-picker
+      - pluginRef: prefix-cache-scorer
+        weight: 50
+  prefix-cache-tracking-config.yaml: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+    - type: single-profile-handler
+    - type: decode-filter
+    - type: prefix-cache-scorer
+      parameters:
+        mode: cache_tracking
+        kvCacheRedisAddr: ${REDIS_HOST}:${REDIS_PORT}
+    - type: load-aware-scorer
+    - type: max-score-picker
+    schedulingProfiles:
+    - name: default
+      plugins:
+      - pluginRef: decode-filter
+      - pluginRef: prefix-cache-scorer
+        weight: 2.0
+      - pluginRef: load-aware-scorer
+        weight: 1.0
+      - pluginRef: max-score-picker
+  prefix-estimate-config.yaml: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+    - type: single-profile-handler
+    - type: decode-filter
+    - type: prefix-cache-scorer
+    - type: load-aware-scorer
+    - type: max-score-picker
+    schedulingProfiles:
+    - name: default
+      plugins:
+      - pluginRef: decode-filter
+      - pluginRef: prefix-cache-scorer
+        weight: 2.0
+      - pluginRef: load-aware-scorer
+        weight: 1.0
+      - pluginRef: max-score-picker
+  default-pd-config.yaml: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+    - type: prefill-header-handler
+    - type: prefix-cache-scorer
+      parameters:
+        hashBlockSize: 5
+        maxPrefixBlocksToMatch: 256
+        lruCapacityPerServer: 31250
+    - type: prefill-filter
+    - type: decode-filter
+    - type: max-score-picker
+    - type: pd-profile-handler
+      parameters:
+        threshold: 10
+        hashBlockSize: 5
+    schedulingProfiles:
+    - name: prefill
+      plugins:
+      - pluginRef: prefill-filter
+      - pluginRef: max-score-picker
+      - pluginRef: prefix-cache-scorer
+        weight: 50
+    - name: decode
+      plugins:
+      - pluginRef: decode-filter
+      - pluginRef: max-score-picker
+      - pluginRef: prefix-cache-scorer
+        weight: 50
+  {{- if (hasKey .Values.routing.epp "pluginsCustomConfig") }}
+  {{- .Values.routing.epp.pluginsCustomConfig | toYaml | nindent 2 }}
+  {{- end }}
+{{- end}}

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -84,7 +84,7 @@ routing:
       port: 9002
       targetPort: 9002
       appProtocol: http2
-    image: ghcr.io/llm-d/llm-d-inference-scheduler:0.0.4
+    image: ghcr.io/llm-d/llm-d-inference-scheduler:0.0.5
     replicas: 1
     debugLevel: 4
     disableReadinessProbe: false
@@ -93,45 +93,36 @@ routing:
     # inferencePool:
     # -- Default environment variables for endpoint picker, use `defaultEnvVarsOverride` to override default behavior by defining the same variable again.
     # Ref: https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/architecture.md#scorers--configuration
+
+    # The name of the plugin file to use. Some default files are provided to you: default-config.yaml, prefix-cache-tracking-config.yaml,
+    # prefix-estimate-config.yaml, default-pd-config.yaml, or you may define a custom config below and select it with the pluginsConfigFile field.
+    pluginsConfigFile: "default-plugin.yaml"
+
+    # Adding a custom plugin config via the pluginsCustomConfig field. Inside there should be an entry to a confimap of file containing the `EndpointPickerConfig`
+    # pluginsCustomConfig:
+    #   custom-plugins.yaml: |
+    #     apiVersion: inference.networking.x-k8s.io/v1alpha1
+    #     kind: EndpointPickerConfig
+    #     plugins:
+    #     - type: custom-scorer
+    #       parameters:
+    #         custom-threshold: 64
+    #     - type: max-score-picker
+    #     - type: single-profile-handler
+    #     schedulingProfiles:
+    #     - name: default
+    #       plugins:
+    #       - pluginRef: custom-scorer
+    #         weight: 1
+    #       - pluginRef: max-score-picker
+    #         weight: 1
+
+
     env:
-    - name: ENABLE_KVCACHE_AWARE_SCORER
-      value: "false"
-    - name: ENABLE_LOAD_AWARE_SCORER
-      value: "true"
-    - name: ENABLE_PREFIX_AWARE_SCORER
-      value: "true"
-    - name: ENABLE_SESSION_AWARE_SCORER
-      value: "false"
-    - name: KVCACHE_AWARE_SCORER_WEIGHT
-      value: "1"
-    - name: KVCACHE_INDEXER_REDIS_ADDR
-    - name: LOAD_AWARE_SCORER_WEIGHT
-      value: "1"
-    - name: PD_ENABLED
-      value: "false"
-    - name: PD_PROMPT_LEN_THRESHOLD
-      value: "10"
-    - name: PREFILL_ENABLE_KVCACHE_AWARE_SCORER
-      value: "false"
-    - name: PREFILL_ENABLE_LOAD_AWARE_SCORER
-      value: "false"
-    - name: PREFILL_ENABLE_PREFIX_AWARE_SCORER
-      value: "false"
-    - name: PREFILL_ENABLE_SESSION_AWARE_SCORER
-      value: "false"
-    - name: PREFILL_KVCACHE_AWARE_SCORER_WEIGHT
-      value: "1"
-    - name: PREFILL_KVCACHE_INDEXER_REDIS_ADDR
-    - name: PREFILL_LOAD_AWARE_SCORER_WEIGHT
-      value: "1"
-    - name: PREFILL_PREFIX_AWARE_SCORER_WEIGHT
-      value: "1"
-    - name: PREFILL_SESSION_AWARE_SCORER_WEIGHT
-      value: "1"
-    - name: PREFIX_AWARE_SCORER_WEIGHT
-      value: "2"
-    - name: SESSION_AWARE_SCORER_WEIGHT
-      value: "1"
+      # Include any Environment variables to epp here, or configure scorers for a legacy epp image, ex:
+    # - name: ENABLE_KVCACHE_AWARE_SCORER
+    #   value: "false"
+
 
 # Decode pod configuration
 decode:


### PR DESCRIPTION
cc @kalantar @sriumcp @vMaroon

These changes should make the `modelservice` chart compatible with upstream GIE and inference scheduler changes