### PR TITLE
maxout httpRoute timeout

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.15
+version: 0.0.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/llm-d-modelservice/templates/httproute.yaml
+++ b/charts/llm-d-modelservice/templates/httproute.yaml
@@ -19,7 +19,10 @@ spec:
   {{- end }}
   {{- else }}
   rules:
-    - backendRefs:
+    - timeouts:
+        backendRequest: "0s"
+        request: "0s"
+      backendRefs:
       - group: inference.networking.x-k8s.io
         kind: InferencePool
         name: {{ include "llm-d-modelservice.inferencePoolName" . }}


### PR DESCRIPTION
Outcome of a way too long hack session - max gateway timeouts were not brought over [from deployer](https://github.com/llm-d/llm-d-deployer/blob/main/charts/llm-d/templates/sample-application/httproutes.yaml#L29-L31) as they should have been. After 15 seconds gateway will abort request which kills all load scenarios.

cc @kalantar 