### PR TITLE
Add optional startupProbe, fix probe rendering

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.18
+version: 0.0.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -332,11 +332,15 @@ context is a dict with helm root context plus:
   {{- (include "llm-d-modelservice.hfEnv" .) | nindent 2 }}
   {{- with .container.livenessProbe }}
   livenessProbe:
-    {{- toYaml . | nindent 2 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .container.readinessProbe }}
   readinessProbe:
-    {{- toYaml . | nindent 2 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .container.startupProbe }}
+  startupProbe:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- (include "llm-d-modelservice.resources" (dict "resources" .container.resources "parallelism" .parallelism)) | nindent 2 }}
   {{- include "llm-d-modelservice.mountModelVolumeVolumeMounts" .container | nindent 2 }}


### PR DESCRIPTION
- Fixes liveness and readiness probe indentions.

```
Before:
          livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /health
            port: 8200
          periodSeconds: 10
          timeoutSeconds: 5
          readinessProbe:
          failureThreshold: 3
          httpGet:
            path: /health
            port: 8200
          periodSeconds: 5
          timeoutSeconds: 2
          startupProbe:
          failureThreshold: 60
          httpGet:
            path: /health
            port: 8200
          initialDelaySeconds: 15
          periodSeconds: 30
          timeoutSeconds: 5

After:

          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /health
              port: 8200
            periodSeconds: 10
            timeoutSeconds: 5
          readinessProbe:
            failureThreshold: 3
            httpGet:
              path: /health
              port: 8200
            periodSeconds: 5
            timeoutSeconds: 2
          startupProbe:
            failureThreshold: 60
            httpGet:
              path: /health
              port: 8200
            initialDelaySeconds: 15
            periodSeconds: 30
            timeoutSeconds: 5
```

Ty!