### PR TITLE
Add scheduler name support

### DIFF
--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -286,8 +286,8 @@ context is a pdSpec
     {{- toYaml . | nindent 2 }}
   {{- end }}
   serviceAccountName: {{ include "llm-d-modelservice.pdServiceAccountName" . }}
-  {{- if .Values.schedulerName }}
-  schedulerName: {{ .Values.schedulerName }}
+  {{- if or .pdSpec.schedulerName .Values.schedulerName }}
+  schedulerName: {{ .pdSpec.schedulerName | default .Values.schedulerName }}
   {{- end }}
   {{- with .pdSpec.podSecurityContext }}
   securityContext:

--- a/charts/llm-d-modelservice/templates/decode-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/decode-deployment.yaml
@@ -26,11 +26,11 @@ spec:
       {{- with .Values.routing }}
       {{- (include "llm-d-modelservice.routingProxy" .) | nindent 6 }}
       {{- end }}
-      {{- (include "llm-d-modelservice.modelPod" (merge . (dict "pdSpec" .Values.decode))) | nindent 4 }}
+      {{- (include "llm-d-modelservice.modelPod" (dict "pdSpec" .Values.decode "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 4 }}
       {{- with .Values.decode.containers }}
       containers:
         {{- range . }}
-        {{- (include "llm-d-modelservice.container" (merge (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism) $)) | nindent 8 }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart)) | nindent 8 }}
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/llm-d-modelservice/templates/decode-lws.yaml
+++ b/charts/llm-d-modelservice/templates/decode-lws.yaml
@@ -48,11 +48,11 @@ spec:
         {{- with .Values.routing }}
         {{ (include "llm-d-modelservice.routingProxy" .) | nindent 8 }}
         {{- end }}
-        {{- (include "llm-d-modelservice.modelPod" (merge . (dict "pdSpec" .Values.decode))) | nindent 6 }}
+        {{- (include "llm-d-modelservice.modelPod" (dict "pdSpec" .Values.decode "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 6 }}
         {{- with .Values.decode.containers }}
         containers:
           {{- range . }}
-        {{- (include "llm-d-modelservice.container" (merge (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism) $)) | nindent 8 }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart)) | nindent 8 }}
           {{- end }}
         {{- end }}
 {{- end }}

--- a/charts/llm-d-modelservice/templates/prefill-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/prefill-deployment.yaml
@@ -23,11 +23,11 @@ spec:
         {{- toYaml .Values.prefill.annotations | nindent 8 }}
       {{- end }}
     spec:
-      {{- (include "llm-d-modelservice.modelPod" (merge . (dict "pdSpec" .Values.prefill))) | nindent 4 }}
+      {{- (include "llm-d-modelservice.modelPod" (dict "pdSpec" .Values.prefill "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 4 }}
       {{- with .Values.prefill.containers }}
       containers:
         {{- range . }}
-        {{- (include "llm-d-modelservice.container" (merge (dict "role" "prefill" "container" . "parallelism" $.Values.prefill.parallelism) $)) | nindent 8 }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "prefill" "container" . "parallelism" $.Values.prefill.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart)) | nindent 8 }}
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/llm-d-modelservice/templates/prefill-lws.yaml
+++ b/charts/llm-d-modelservice/templates/prefill-lws.yaml
@@ -46,13 +46,13 @@ spec:
         hostIPC: {{ .Values.prefill.hostIPC }}
         {{- end }}
         {{- if hasKey .Values.prefill "hostPID" }}
-        hostPID: {{ .Values.decprefillode.hostPID }}
+        hostPID: {{ .Values.prefill.hostPID }}
         {{- end }}
-        {{- (include "llm-d-modelservice.modelPod" (merge . (dict "pdSpec" .Values.prefill))) | nindent 6 }}
+        {{- (include "llm-d-modelservice.modelPod" (dict "pdSpec" .Values.prefill "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 6 }}
         {{- with .Values.prefill.containers }}
         containers:
           {{- range . }}
-        {{- (include "llm-d-modelservice.container" (merge (dict "role" "prefill" "container" . "parallelism" $.Values.prefill.parallelism) $)) | nindent 8 }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "prefill" "container" . "parallelism" $.Values.prefill.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart)) | nindent 8 }}
           {{- end }}
         {{- end }}
 

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -151,6 +151,8 @@ decode:
     enabled: false
 
   replicas: 1
+  # schedulerName -- Name of the scheduler to use for scheduling decode pods (overrides global schedulerName)
+  # schedulerName: decode-scheduler
   containers:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d-inference-sim:v0.3.0"
@@ -194,6 +196,8 @@ prefill:
     enabled: false
 
   replicas: 0
+  # schedulerName -- Name of the scheduler to use for scheduling prefill pods (overrides global schedulerName)
+  # schedulerName: prefill-scheduler
   containers:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d-inference-sim:v0.3.0"


### PR DESCRIPTION
Add support for setting scheduler name globally for both P/D and individually.  

Also fix a context isolation bug, reproducible via this:
```
helm template test-release charts/llm-d-modelservice --set decode.podSecurityContext.runAsUser=1000 --set prefill.podSecurityContext.runAsUser=2000
```
Both pods will get `runAsUser=2000`

Also fixed typo in HostPID.