### PR TITLE
bump image versions

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.20
+version: v0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.2.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -101,7 +101,7 @@ routing:
       port: 9002
       targetPort: 9002
       appProtocol: http2
-    image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.2.0
+    image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.2.1
     replicas: 1
     debugLevel: 4
     disableReadinessProbe: false

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ Note: `alias k=kubectl`
 
 > If you only want to deploy model instances without routing support, append `--set inferencePool=false --set httpRoute=false` to the example commands.
 
-1. CPU-only in Kind
+1. CPU-only
 
     Make sure there is a gateway (Kgateway or Istio) deployed in the cluster. Follow [these instructions](https://gateway-api-inference-extension.sigs.k8s.io/guides/#__tabbed_3_2) on how to set up a gateway. Once done, update `routing.parentRefs[*].name` in this [values file](values-cpu.yaml#L18) to use the name for the Gateway (`llm-d-inference-gateway-istio`) in the cluster or override with the `--set "routing.parentRefs[0].name=MYGATEWAY"` flag.
 
@@ -23,7 +23,7 @@ Note: `alias k=kubectl`
     helm template cpu-sim llm-d-modelservice/llm-d-modelservice -f https://raw.githubusercontent.com/llm-d-incubation/llm-d-modelservice/refs/heads/main/examples/values-cpu.yaml
     ```
 
-    To install in a Kind cluster, use `helm install` instead of `helm template`:
+    To install, use `helm install` instead of `helm template`:
 
     ```
     helm install cpu-sim llm-d-modelservice/llm-d-modelservice -f https://raw.githubusercontent.com/llm-d-incubation/llm-d-modelservice/refs/heads/main/examples/values-cpu.yaml

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -3,28 +3,28 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vllm-sim-llm-d-modelservice-epp
+  name: cpu-sim-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: llm-d-modelservice/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vllm-sim-llm-d-modelservice
+  name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: llm-d-modelservice/templates/epp-plugin-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vllm-sim-llm-d-modelservice-epp
-  namespace: e2e-solution
+  name: cpu-sim-llm-d-modelservice-epp
+  namespace: default
 data:
   default-config.yaml: |
     apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -128,7 +128,7 @@ data:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: vllm-sim-llm-d-modelservice-epp
+  name: cpu-sim-llm-d-modelservice-epp
 rules:
 - apiGroups:
   - inference.networking.x-k8s.io
@@ -172,23 +172,23 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: vllm-sim-llm-d-modelservice-epp
+  name: cpu-sim-llm-d-modelservice-epp
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: vllm-sim-llm-d-modelservice-epp
+  name: cpu-sim-llm-d-modelservice-epp
 subjects:
 - kind: ServiceAccount
-  name: vllm-sim-llm-d-modelservice-epp
+  name: cpu-sim-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/epp-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: vllm-sim-llm-d-modelservice-epp
+  name: cpu-sim-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -199,29 +199,29 @@ spec:
       protocol: TCP
       appProtocol: http2
   selector:
-    llm-d.ai/epp: vllm-sim-llm-d-modelservice-epp
+    llm-d.ai/epp: cpu-sim-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/decode-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-sim-llm-d-modelservice-decode
+  name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
   selector:
     matchLabels:
       llm-d.ai/inferenceServing: "true"
-      llm-d.ai/model: vllm-sim-llm-d-modelservice
+      llm-d.ai/model: cpu-sim-llm-d-modelservice
       llm-d.ai/role: decode
   template:
     metadata:
       labels:
         llm-d.ai/inferenceServing: "true"
-        llm-d.ai/model: vllm-sim-llm-d-modelservice
+        llm-d.ai/model: cpu-sim-llm-d-modelservice
         llm-d.ai/role: decode
     spec:
       initContainers:
@@ -232,7 +232,7 @@ spec:
             - --connector=nixlv2
             - -v=5
             - --secure-proxy=false
-          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.2.0-rc2
+          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.2.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
@@ -242,7 +242,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
     
-      serviceAccountName: vllm-sim-llm-d-modelservice
+      serviceAccountName: cpu-sim-llm-d-modelservice
       volumes:
         - emptyDir: {}
           name: metrics-volume
@@ -283,29 +283,29 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-sim-llm-d-modelservice-epp
+  name: cpu-sim-llm-d-modelservice-epp
   labels:
-    llm-d.ai/epp: vllm-sim-llm-d-modelservice-epp
-  namespace: e2e-solution
+    llm-d.ai/epp: cpu-sim-llm-d-modelservice-epp
+  namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      llm-d.ai/epp: vllm-sim-llm-d-modelservice-epp
+      llm-d.ai/epp: cpu-sim-llm-d-modelservice-epp
   template:
     metadata:
       labels:
-        llm-d.ai/epp: vllm-sim-llm-d-modelservice-epp
+        llm-d.ai/epp: cpu-sim-llm-d-modelservice-epp
     spec:
       containers:
       - name: epp
         imagePullPolicy: Always
-        image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.2.0
+        image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.2.1
         args:
         - --poolName
-        - vllm-sim-llm-d-modelservice
+        - cpu-sim-llm-d-modelservice
         - --poolNamespace
-        - e2e-solution
+        - default
         - -v
         - "6"
         - --zap-encoder
@@ -332,35 +332,35 @@ spec:
       volumes:
       - name: plugins-config-volume
         configMap:
-          name: vllm-sim-llm-d-modelservice-epp
-      serviceAccount: vllm-sim-llm-d-modelservice-epp
-      serviceAccountName: vllm-sim-llm-d-modelservice-epp
+          name: cpu-sim-llm-d-modelservice-epp
+      serviceAccount: cpu-sim-llm-d-modelservice-epp
+      serviceAccountName: cpu-sim-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/prefill-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-sim-llm-d-modelservice-prefill
+  name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
   selector:
     matchLabels:
       llm-d.ai/inferenceServing: "true"
-      llm-d.ai/model: vllm-sim-llm-d-modelservice
+      llm-d.ai/model: cpu-sim-llm-d-modelservice
       llm-d.ai/role: prefill
   template:
     metadata:
       labels:
         llm-d.ai/inferenceServing: "true"
-        llm-d.ai/model: vllm-sim-llm-d-modelservice
+        llm-d.ai/model: cpu-sim-llm-d-modelservice
         llm-d.ai/role: prefill
     spec:
     
-      serviceAccountName: vllm-sim-llm-d-modelservice
+      serviceAccountName: cpu-sim-llm-d-modelservice
       volumes:
         - emptyDir: {}
           name: metrics-volume
@@ -401,11 +401,11 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: vllm-sim-llm-d-modelservice
-  namespace: e2e-solution
+  name: cpu-sim-llm-d-modelservice
+  namespace: default
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   parentRefs:
@@ -419,7 +419,7 @@ spec:
       backendRefs:
       - group: inference.networking.x-k8s.io
         kind: InferencePool
-        name: vllm-sim-llm-d-modelservice
+        name: cpu-sim-llm-d-modelservice
         port: 8000
         weight: 1
       matches:
@@ -435,15 +435,15 @@ spec:
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
-  name: vllm-sim-llm-d-modelservice
-  namespace: e2e-solution
+  name: cpu-sim-llm-d-modelservice
+  namespace: default
 spec:
   extensionRef:
     failureMode: FailClose
     group: ""
     kind: Service
-    name: vllm-sim-llm-d-modelservice-epp
+    name: cpu-sim-llm-d-modelservice-epp
   selector:
     llm-d.ai/inferenceServing: "true"
-    llm-d.ai/model: vllm-sim-llm-d-modelservice
+    llm-d.ai/model: cpu-sim-llm-d-modelservice
   targetPortNumber: 8000

--- a/examples/output-one-pod-per-dp-rank.yaml
+++ b/examples/output-one-pod-per-dp-rank.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: qwen-lws-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.11
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: llm-d-modelservice/templates/httproute.yaml
@@ -16,8 +16,8 @@ metadata:
   name: qwen-lws-llm-d-modelservice
   namespace: default
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.11
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   parentRefs:
@@ -25,7 +25,10 @@ spec:
     kind: Gateway
     name: infra-wide-pd-inference-gateway
   rules:
-    - backendRefs:
+    - timeouts:
+        backendRequest: "0s"
+        request: "0s"
+      backendRefs:
       - group: inference.networking.x-k8s.io
         kind: InferencePool
         name: gaie-pd
@@ -45,6 +48,7 @@ metadata:
     llm-d.ai/model: qwen-lws-llm-d-modelservice
   name: qwen-lws-llm-d-modelservice
 spec:
+  criticality: Critical
   modelName: Qwen/Qwen3-30B-A3B-FP8
   poolRef:
     name: gaie-pd
@@ -55,8 +59,8 @@ kind: LeaderWorkerSet
 metadata:
   name: qwen-lws-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.11
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/inferenceServing: "true"
     llm-d.ai/model: qwen-lws-llm-d-modelservice
@@ -75,6 +79,8 @@ spec:
           llm-d.ai/inferenceServing: "true"
           llm-d.ai/model: qwen-lws-llm-d-modelservice
           llm-d.ai/role: decode
+        annotations:
+          leaderworkerset.sigs.k8s.io/subgroup-exclusive-topology: kubernetes.io/hostname
       spec:
         hostIPC: true
         hostPID: true
@@ -86,7 +92,7 @@ spec:
               - --vllm-port=8200
               - --connector=nixlv2
               - -v=5
-            image: ghcr.io/llm-d/llm-d-routing-sidecar:0.0.6
+            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.2.0
             imagePullPolicy: Always
             ports:
               - containerPort: 8000
@@ -107,12 +113,14 @@ spec:
                     values:
                       - H200
         volumes:
+          - emptyDir: {}
+            name: metrics-volume
           - name: model-storage
             emptyDir: 
               sizeLimit: 100Gi
         containers:
         - name: vllm-worker-decode
-          image: quay.io/tms/vllm-dev-deepep:0.1.0
+          image: ghcr.io/llm-d/llm-d-dev:v0.2.0-rc.1
           securityContext:
             capabilities:
               add:
@@ -229,8 +237,8 @@ kind: LeaderWorkerSet
 metadata:
   name: qwen-lws-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.11
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/inferenceServing: "true"
     llm-d.ai/model: qwen-lws-llm-d-modelservice
@@ -252,6 +260,8 @@ spec:
           llm-d.ai/inferenceServing: "true"
           llm-d.ai/model: qwen-lws-llm-d-modelservice
           llm-d.ai/role: prefill
+        annotations:
+          leaderworkerset.sigs.k8s.io/subgroup-exclusive-topology: kubernetes.io/hostname
       spec:
         hostIPC: true
         hostPID: true
@@ -267,12 +277,14 @@ spec:
                     values:
                       - H200
         volumes:
+          - emptyDir: {}
+            name: metrics-volume
           - name: model-storage
             emptyDir: 
               sizeLimit: 100Gi
         containers:
         - name: vllm-worker-prefill
-          image: quay.io/tms/vllm-dev-deepep:0.1.0
+          image: ghcr.io/llm-d/llm-d-dev:v0.2.0-rc.1
           securityContext:
             capabilities:
               add:

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -3,28 +3,28 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: facebook-llm-d-modelservice-epp
+  name: facebook-pd-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: llm-d-modelservice/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: facebook-llm-d-modelservice
+  name: facebook-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: llm-d-modelservice/templates/epp-plugin-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: facebook-llm-d-modelservice-epp
-  namespace: e2e-solution
+  name: facebook-pd-llm-d-modelservice-epp
+  namespace: default
 data:
   default-config.yaml: |
     apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -128,7 +128,7 @@ data:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: facebook-llm-d-modelservice-epp
+  name: facebook-pd-llm-d-modelservice-epp
 rules:
 - apiGroups:
   - inference.networking.x-k8s.io
@@ -172,23 +172,23 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: facebook-llm-d-modelservice-epp
+  name: facebook-pd-llm-d-modelservice-epp
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: facebook-llm-d-modelservice-epp
+  name: facebook-pd-llm-d-modelservice-epp
 subjects:
 - kind: ServiceAccount
-  name: facebook-llm-d-modelservice-epp
+  name: facebook-pd-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/epp-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: facebook-llm-d-modelservice-epp
+  name: facebook-pd-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -199,29 +199,29 @@ spec:
       protocol: TCP
       appProtocol: http2
   selector:
-    llm-d.ai/epp: facebook-llm-d-modelservice-epp
+    llm-d.ai/epp: facebook-pd-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/decode-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: facebook-llm-d-modelservice-decode
+  name: facebook-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
   selector:
     matchLabels:
       llm-d.ai/inferenceServing: "true"
-      llm-d.ai/model: facebook-llm-d-modelservice
+      llm-d.ai/model: facebook-pd-llm-d-modelservice
       llm-d.ai/role: decode
   template:
     metadata:
       labels:
         llm-d.ai/inferenceServing: "true"
-        llm-d.ai/model: facebook-llm-d-modelservice
+        llm-d.ai/model: facebook-pd-llm-d-modelservice
         llm-d.ai/role: decode
     spec:
       initContainers:
@@ -232,7 +232,7 @@ spec:
             - --connector=nixlv2
             - -v=5
             - --secure-proxy=false
-          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.2.0-rc2
+          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.2.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
@@ -242,7 +242,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
     
-      serviceAccountName: facebook-llm-d-modelservice
+      serviceAccountName: facebook-pd-llm-d-modelservice
       volumes:
         - emptyDir: {}
           name: metrics-volume
@@ -251,7 +251,7 @@ spec:
             sizeLimit: 20Gi
       containers:
         - name: vllm
-          image: ghcr.io/llm-d/llm-d:0.0.8
+          image: ghcr.io/llm-d/llm-d-dev:v0.2.0-rc.1
           
           command: ["vllm", "serve"]
           args:
@@ -303,29 +303,29 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: facebook-llm-d-modelservice-epp
+  name: facebook-pd-llm-d-modelservice-epp
   labels:
-    llm-d.ai/epp: facebook-llm-d-modelservice-epp
-  namespace: e2e-solution
+    llm-d.ai/epp: facebook-pd-llm-d-modelservice-epp
+  namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      llm-d.ai/epp: facebook-llm-d-modelservice-epp
+      llm-d.ai/epp: facebook-pd-llm-d-modelservice-epp
   template:
     metadata:
       labels:
-        llm-d.ai/epp: facebook-llm-d-modelservice-epp
+        llm-d.ai/epp: facebook-pd-llm-d-modelservice-epp
     spec:
       containers:
       - name: epp
         imagePullPolicy: Always
-        image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.2.0
+        image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.2.1
         args:
         - --poolName
-        - facebook-llm-d-modelservice
+        - facebook-pd-llm-d-modelservice
         - --poolNamespace
-        - e2e-solution
+        - default
         - -v
         - "4"
         - --zap-encoder
@@ -370,35 +370,35 @@ spec:
       volumes:
       - name: plugins-config-volume
         configMap:
-          name: facebook-llm-d-modelservice-epp
-      serviceAccount: facebook-llm-d-modelservice-epp
-      serviceAccountName: facebook-llm-d-modelservice-epp
+          name: facebook-pd-llm-d-modelservice-epp
+      serviceAccount: facebook-pd-llm-d-modelservice-epp
+      serviceAccountName: facebook-pd-llm-d-modelservice-epp
 ---
 # Source: llm-d-modelservice/templates/prefill-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: facebook-llm-d-modelservice-prefill
+  name: facebook-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
   selector:
     matchLabels:
       llm-d.ai/inferenceServing: "true"
-      llm-d.ai/model: facebook-llm-d-modelservice
+      llm-d.ai/model: facebook-pd-llm-d-modelservice
       llm-d.ai/role: prefill
   template:
     metadata:
       labels:
         llm-d.ai/inferenceServing: "true"
-        llm-d.ai/model: facebook-llm-d-modelservice
+        llm-d.ai/model: facebook-pd-llm-d-modelservice
         llm-d.ai/role: prefill
     spec:
     
-      serviceAccountName: facebook-llm-d-modelservice
+      serviceAccountName: facebook-pd-llm-d-modelservice
       volumes:
         - emptyDir: {}
           name: metrics-volume
@@ -407,7 +407,7 @@ spec:
             sizeLimit: 20Gi
       containers:
         - name: vllm
-          image: ghcr.io/llm-d/llm-d:0.0.8
+          image: ghcr.io/llm-d/llm-d-dev:v0.2.0-rc.1
           
           command: ["vllm", "serve"]
           args:
@@ -453,11 +453,11 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: facebook-llm-d-modelservice
-  namespace: e2e-solution
+  name: facebook-pd-llm-d-modelservice
+  namespace: default
   labels:
-    helm.sh/chart: llm-d-modelservice-0.0.19
-    app.kubernetes.io/version: "0.0.1"
+    helm.sh/chart: llm-d-modelservice-0.2.0
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   parentRefs:
@@ -471,7 +471,7 @@ spec:
       backendRefs:
       - group: inference.networking.x-k8s.io
         kind: InferencePool
-        name: facebook-llm-d-modelservice
+        name: facebook-pd-llm-d-modelservice
         port: 8000
         weight: 1
       matches:
@@ -489,27 +489,27 @@ kind: InferenceModel
 metadata:
   labels:
     llm-d.ai/inferenceServing: "true"
-    llm-d.ai/model: facebook-llm-d-modelservice
-  name: facebook-llm-d-modelservice
+    llm-d.ai/model: facebook-pd-llm-d-modelservice
+  name: facebook-pd-llm-d-modelservice
 spec:
   criticality: Critical
   modelName: facebook/opt-125m
   poolRef:
-    name: facebook-llm-d-modelservice
+    name: facebook-pd-llm-d-modelservice
 ---
 # Source: llm-d-modelservice/templates/inferencepool.yaml
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
-  name: facebook-llm-d-modelservice
-  namespace: e2e-solution
+  name: facebook-pd-llm-d-modelservice
+  namespace: default
 spec:
   extensionRef:
     failureMode: FailClose
     group: ""
     kind: Service
-    name: facebook-llm-d-modelservice-epp
+    name: facebook-pd-llm-d-modelservice-epp
   selector:
     llm-d.ai/inferenceServing: "true"
-    llm-d.ai/model: facebook-llm-d-modelservice
+    llm-d.ai/model: facebook-pd-llm-d-modelservice
   targetPortNumber: 8000

--- a/examples/values-one-pod-per-dp-rank.yaml
+++ b/examples/values-one-pod-per-dp-rank.yaml
@@ -52,7 +52,7 @@ decode:
   subGroupExclusiveTopology: true
   containers:
     - name: vllm-worker-decode
-      image: "quay.io/tms/vllm-dev-deepep:0.1.0"
+      image: "ghcr.io/llm-d/llm-d-dev:v0.2.0-rc.1"
       imagePullPolicy: Always
       workingDir: /code
       command: ["/bin/bash","-c"]
@@ -178,7 +178,7 @@ prefill:
   subGroupExclusiveTopology: true
   containers:
     - name: vllm-worker-prefill
-      image: "quay.io/tms/vllm-dev-deepep:0.1.0"
+      image: "ghcr.io/llm-d/llm-d-dev:v0.2.0-rc.1"
       imagePullPolicy: Always
       workingDir: /code
       command: ["/bin/bash","-c"]

--- a/examples/values-one-pod-per-dp-rank.yaml
+++ b/examples/values-one-pod-per-dp-rank.yaml
@@ -45,6 +45,11 @@ decode:
   parallelism:
     data: 8 # these will be derived based performance testing
     tensor: 1 # these will be derived based performance testing
+  hostIPC: true
+  hostPID: true
+  subGroupPolicy:
+    subGroupSize: 8
+  subGroupExclusiveTopology: true
   containers:
     - name: vllm-worker-decode
       image: "quay.io/tms/vllm-dev-deepep:0.1.0"
@@ -166,6 +171,11 @@ prefill:
   parallelism:
     data: 8 # these will be derived based performance testing
     tensor: 1 # these will be derived based performance testing
+  hostIPC: true
+  hostPID: true
+  subGroupPolicy:
+    subGroupSize: 8
+  subGroupExclusiveTopology: true
   containers:
     - name: vllm-worker-prefill
       image: "quay.io/tms/vllm-dev-deepep:0.1.0"

--- a/examples/values-pd.yaml
+++ b/examples/values-pd.yaml
@@ -54,7 +54,7 @@ decode:
   replicas: 1
   containers:
   - name: "vllm"
-    image: "ghcr.io/llm-d/llm-d:0.0.8"
+    image: "ghcr.io/llm-d/llm-d-dev:v0.2.0-rc.1"
     modelCommand: vllmServe
     args:
       - "--enforce-eager"
@@ -93,7 +93,7 @@ prefill:
   replicas: 1
   containers:
   - name: "vllm"
-    image: "ghcr.io/llm-d/llm-d:0.0.8"
+    image: "ghcr.io/llm-d/llm-d-dev:v0.2.0-rc.1"
     modelCommand: vllmServe
     args:
       - "--enforce-eager"


### PR DESCRIPTION
The PR:
- updates the default image for inference-scheduler
-
- updates chart version to v0.2.0