### PR TITLE
feat: add `make generate` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
 # Makefile for llm-d-modelservice
 
+##@ Development
+# Paths that need verification during 'make verify'
 PATHS_TO_VERIFY := examples/
+
 .PHONY: verify
-verify: generate-example-output
+verify: generate ## Verify that generated files match current state
 	git --no-pager diff --exit-code $(PATHS_TO_VERIFY)
 	if git ls-files --exclude-standard --others $(PATHS_TO_VERIFY) | grep -q . ; then exit 1; fi
 
-.PHONY: generate-example-output
-generate-example-output:
+##@ Automation
+
+.PHONY: generate
+generate: ## Generate example output files from Helm chart templates
 	hack/generate-example-output.sh

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -188,7 +188,7 @@ kind: Service
 metadata:
   name: cpu-sim-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -208,7 +208,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -347,7 +347,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -430,7 +430,7 @@ metadata:
   name: cpu-sim-llm-d-modelservice
   namespace: default
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
@@ -442,15 +442,15 @@ spec:
     name: inference-gateway
     namespace: 'default'
   rules:
-    - timeouts:
-        backendRequest: "0s"
-        request: "0s"
-      backendRefs:
+    - backendRefs:
       - group: inference.networking.x-k8s.io
         kind: InferencePool
         name: cpu-sim-llm-d-modelservice
         port: 8000
         weight: 1
+      timeouts:
+        backendRequest: 0s
+        request: 0s
       matches:
       - headers:
         - name: x-model-name

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -188,7 +188,7 @@ kind: Service
 metadata:
   name: pd-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -208,7 +208,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -387,7 +387,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -506,7 +506,7 @@ metadata:
   name: pd-llm-d-modelservice
   namespace: default
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
@@ -518,15 +518,15 @@ spec:
     name: inference-gateway
     namespace: 'default'
   rules:
-    - timeouts:
-        backendRequest: "0s"
-        request: "0s"
-      backendRefs:
+    - backendRefs:
       - group: inference.networking.x-k8s.io
         kind: InferencePool
         name: pd-llm-d-modelservice
         port: 8000
         weight: 1
+      timeouts:
+        backendRequest: 0s
+        request: 0s
       matches:
       - headers:
         - name: x-model-name

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -188,7 +188,7 @@ kind: Service
 metadata:
   name: pvc-hf-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -208,7 +208,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -387,7 +387,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -506,7 +506,7 @@ metadata:
   name: pvc-hf-llm-d-modelservice
   namespace: default
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
@@ -518,15 +518,15 @@ spec:
     name: inference-gateway
     namespace: 'default'
   rules:
-    - timeouts:
-        backendRequest: "0s"
-        request: "0s"
-      backendRefs:
+    - backendRefs:
       - group: inference.networking.x-k8s.io
         kind: InferencePool
         name: pvc-hf-llm-d-modelservice
         port: 8000
         weight: 1
+      timeouts:
+        backendRequest: 0s
+        request: 0s
       matches:
       - headers:
         - name: x-model-name

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -188,7 +188,7 @@ kind: Service
 metadata:
   name: pvc-llm-d-modelservice-epp
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -208,7 +208,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -385,7 +385,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -502,7 +502,7 @@ metadata:
   name: pvc-llm-d-modelservice
   namespace: default
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.2.6
+    helm.sh/chart: llm-d-modelservice-v0.2.7
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
@@ -514,15 +514,15 @@ spec:
     name: inference-gateway
     namespace: 'default'
   rules:
-    - timeouts:
-        backendRequest: "0s"
-        request: "0s"
-      backendRefs:
+    - backendRefs:
       - group: inference.networking.x-k8s.io
         kind: InferencePool
         name: pvc-llm-d-modelservice
         port: 8000
         weight: 1
+      timeouts:
+        backendRequest: 0s
+        request: 0s
       matches:
       - headers:
         - name: x-model-name


### PR DESCRIPTION
This PR introduces a `make generate` command to generate example outputs, which can also be used to automatically generate other content in the future.

ref to https://github.com/llm-d-incubation/llm-d-modelservice/issues/89#issuecomment-3198024955.
fix: #89
