### PR TITLE
feat: Add `make lint` for Helm chart linting infrastructure

### DIFF
--- a/.github/workflows/lint-charts.yaml
+++ b/.github/workflows/lint-charts.yaml
@@ -38,9 +38,11 @@ jobs:
             helm dependency list  --max-col-width 120 $dir 2> /dev/null | tail +2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
           done
 
-      - name: Run chart-testing (lint)
+      - name: Run make lint for chart-testing
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=false --validate-maintainers=false
+        env:
+          TARGET_BRANCH: ${{ github.event.repository.default_branch }}
+        run: make lint
 
       - name: Run make verify
         run: make verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ For every Pull Request submitted, ensure the following steps have been done:
 
 1. [Sign your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 2. [Sign-off your commits](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt-code--signoffcode)
-3. Ensure that the `make verify` command runs successfully to validate your changes
+3. Ensure that the `make lint`, `make verify` command runs successfully to validate your changes
 4. Update the version number in the [`charts/llm-d-modelservice/Chart.yaml`](charts/llm-d-modelservice/Chart.yaml) file using
    [semantic versioning](https://semver.org/). Follow the `X.Y.Z` format so the nature of the changes is reflected in the
    chart.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,20 @@
 # Makefile for llm-d-modelservice
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
+
+.PHONY: pre-helm
+pre-helm: ## Set up Helm dependency repositories
+	helm repo add bitnami https://charts.bitnami.com/bitnami
+
+.PHONY: lint
+lint: pre-helm ## Run lint checks using helm-lint
+	ct lint --check-version-increment=false --validate-maintainers=false --charts charts/llm-d-modelservice $(if $(TARGET_BRANCH),--target-branch $(TARGET_BRANCH))
+
 # Paths that need verification during 'make verify'
 PATHS_TO_VERIFY := examples/
 
@@ -14,3 +28,4 @@ verify: generate ## Verify that generated files match current state
 .PHONY: generate
 generate: ## Generate example output files from Helm chart templates
 	hack/generate-example-output.sh
+

--- a/chart_schema.yaml
+++ b/chart_schema.yaml
@@ -1,0 +1,37 @@
+name: str()
+home: str(required=False)
+version: str()
+apiVersion: str()
+appVersion: any(str(), num(), required=False)
+description: str(required=False)
+keywords: list(str(), required=False)
+sources: list(str(), required=False)
+maintainers: list(include('maintainer'), required=False)
+dependencies: list(include('dependency'), required=False)
+icon: str(required=False)
+engine: str(required=False)
+condition: str(required=False)
+tags: str(required=False)
+deprecated: bool(required=False)
+kubeVersion: str(required=False)
+annotations: map(str(), str(), required=False)
+type: str(required=False)
+---
+maintainer:
+  name: str()
+  email: str(required=False)
+  url: str(required=False)
+---
+dependency:
+  name: str()
+  version: str()
+  repository: str(required=False)
+  condition: str(required=False)
+  tags: list(str(), required=False)
+  enabled: bool(required=False)
+  import-values: list(any(str(), include('import-value')), required=False)
+  alias: str(required=False)
+---
+import-value:
+  child: str()
+  parent: str()

--- a/lintconf.yaml
+++ b/lintconf.yaml
@@ -1,0 +1,3 @@
+rules:
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
## Summary
This PR introduces comprehensive linting infrastructure for the Helm chart, including 
- make lint for chart testing
- `.gitignore` to exclude binaries, chart dependencies
- make help
- automated tool installation

fix: #98

TODO: after the contribution guidelines #99 is merged. The `make lint` sections should be updated in the documentation (it may in another PR).

## require discussion by reviewers

The `chart_schema.yaml` file is located in the project directory, not in the chart directory, differing from https://github.com/llm-d/llm-d-deployer/blob/main/charts/llm-d/chart_schema.yaml, because `chart_schema.yaml` and `lintconf.yaml` are handled the same way in the chart-testing project.

Your suggestions are welcome


## Testing
### Make Help
```bash
root@gpu-3090:~/oss/llm-d-modelservice# make help

Usage:
  make <target>
  help             Display this help.

Development
  helm-repos       Set up Helm repositories
  helm-lint        Run helm lint on the specified chart
  lint             Run lint checks using helm-lint
  verify           Verify that generated files match current state

Automation
  generate         Generate example output files from Helm chart templates
```
### Make lint
```bash
root@gpu-3090:~/oss/llm-d-modelservice# make lint
helm repo add bitnami https://charts.bitnami.com/bitnami
"bitnami" already exists with the same configuration, skipping
ct lint --check-version-increment=false --validate-maintainers=false --all
Linting charts...
Version increment checking disabled.

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 llm-d-modelservice => (version: "v0.2.7", path: "charts/llm-d-modelservice")
------------------------------------------------------------------------------------------------------------------------

Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "llm-d-modelservice" chart repository
...Successfully got an update from the "headlamp" chart repository
...Successfully got an update from the "nvidia" chart repository
...Successfully got an update from the "prometheus-community" chart repository
...Successfully got an update from the "bitnami" chart repository
...Successfully got an update from the "common" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading common from repo https://charts.bitnami.com/bitnami
Deleting outdated charts
Linting chart "llm-d-modelservice => (version: \"v0.2.7\", path: \"charts/llm-d-modelservice\")"
Validating charts/llm-d-modelservice/Chart.yaml...
Validation success! 👍
==> Linting charts/llm-d-modelservice
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ llm-d-modelservice => (version: "v0.2.7", path: "charts/llm-d-modelservice")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```
