### PR TITLE
Use explicit path for ct command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ pre-helm: tools ## Set up Helm dependency repositories
 
 .PHONY: lint
 lint: pre-helm ## Run lint checks using helm-lint
-	ct lint --check-version-increment=false --validate-maintainers=false --charts charts/llm-d-modelservice $(if $(TARGET_BRANCH),--target-branch $(TARGET_BRANCH))
+	$(PROJECT_DIR)/bin/ct lint --check-version-increment=false --validate-maintainers=false --charts charts/llm-d-modelservice $(if $(TARGET_BRANCH),--target-branch $(TARGET_BRANCH))
 
 # Paths that need verification during 'make verify'
 PATHS_TO_VERIFY := examples/

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ pre-helm: tools ## Set up Helm dependency repositories
 
 .PHONY: lint
 lint: pre-helm ## Run lint checks using helm-lint
-	$(PROJECT_DIR)/bin/ct lint --check-version-increment=false --validate-maintainers=false --charts charts/llm-d-modelservice $(if $(TARGET_BRANCH),--target-branch $(TARGET_BRANCH))
+	$(eval CT := $(shell which ct 2>/dev/null || echo "$(PROJECT_DIR)/bin/ct"))
+	$(CT) lint --check-version-increment=false --validate-maintainers=false --charts charts/llm-d-modelservice $(if $(TARGET_BRANCH),--target-branch $(TARGET_BRANCH))
 
 # Paths that need verification during 'make verify'
 PATHS_TO_VERIFY := examples/


### PR DESCRIPTION
The make lint command was failing because it couldn't find the ct binary even though the PATH was set correctly. 
The helm command worked fine with the same PATH setup, but ct didn't.

I fixed it by changing the Makefile to use the explicit path $(PROJECT_DIR)/bin/ct instead of just ct. 
Now make lint works properly and can run the chart linting successfully.