### PR TITLE
allow specifying api-group for inf-pool

### DIFF
--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -25,7 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cpu-sim-llm-d-modelservice-epp
-  namespace: llm-d-wide-ep
+  namespace: default
 data:
   default-config.yaml: |
     apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -292,7 +292,7 @@ metadata:
   name: cpu-sim-llm-d-modelservice-epp
   labels:
     llm-d.ai/epp: cpu-sim-llm-d-modelservice-epp
-  namespace: llm-d-wide-ep
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -311,7 +311,7 @@ spec:
         - --poolName
         - cpu-sim-llm-d-modelservice
         - --poolNamespace
-        - llm-d-wide-ep
+        - default
         - -v
         - "6"
         - --zap-encoder
@@ -413,7 +413,7 @@ apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
   name: cpu-sim-llm-d-modelservice
-  namespace: llm-d-wide-ep
+  namespace: default
 spec:
   extensionRef:
     failureMode: FailClose
@@ -430,7 +430,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: cpu-sim-llm-d-modelservice
-  namespace: llm-d-wide-ep
+  namespace: default
   labels:
     helm.sh/chart: llm-d-modelservice-v0.2.8
     app.kubernetes.io/version: "v0.2.0"
@@ -442,7 +442,7 @@ spec:
   - group: gateway.networking.k8s.io
     kind: Gateway
     name: inference-gateway
-    namespace: 'llm-d-wide-ep'
+    namespace: 'default'
   rules:
     - backendRefs:
       - group: inference.networking.x-k8s.io

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -25,7 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pd-llm-d-modelservice-epp
-  namespace: llm-d-wide-ep
+  namespace: default
 data:
   default-config.yaml: |
     apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -314,7 +314,7 @@ metadata:
   name: pd-llm-d-modelservice-epp
   labels:
     llm-d.ai/epp: pd-llm-d-modelservice-epp
-  namespace: llm-d-wide-ep
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -333,7 +333,7 @@ spec:
         - --poolName
         - pd-llm-d-modelservice
         - --poolNamespace
-        - llm-d-wide-ep
+        - default
         - -v
         - "4"
         - --zap-encoder
@@ -489,7 +489,7 @@ apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
   name: pd-llm-d-modelservice
-  namespace: llm-d-wide-ep
+  namespace: default
 spec:
   extensionRef:
     failureMode: FailClose
@@ -506,7 +506,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: pd-llm-d-modelservice
-  namespace: llm-d-wide-ep
+  namespace: default
   labels:
     helm.sh/chart: llm-d-modelservice-v0.2.8
     app.kubernetes.io/version: "v0.2.0"
@@ -518,7 +518,7 @@ spec:
   - group: gateway.networking.k8s.io
     kind: Gateway
     name: inference-gateway
-    namespace: 'llm-d-wide-ep'
+    namespace: 'default'
   rules:
     - backendRefs:
       - group: inference.networking.x-k8s.io

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -25,7 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pvc-hf-llm-d-modelservice-epp
-  namespace: llm-d-wide-ep
+  namespace: default
 data:
   default-config.yaml: |
     apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -314,7 +314,7 @@ metadata:
   name: pvc-hf-llm-d-modelservice-epp
   labels:
     llm-d.ai/epp: pvc-hf-llm-d-modelservice-epp
-  namespace: llm-d-wide-ep
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -333,7 +333,7 @@ spec:
         - --poolName
         - pvc-hf-llm-d-modelservice
         - --poolNamespace
-        - llm-d-wide-ep
+        - default
         - -v
         - "4"
         - --zap-encoder
@@ -489,7 +489,7 @@ apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
   name: pvc-hf-llm-d-modelservice
-  namespace: llm-d-wide-ep
+  namespace: default
 spec:
   extensionRef:
     failureMode: FailClose
@@ -506,7 +506,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: pvc-hf-llm-d-modelservice
-  namespace: llm-d-wide-ep
+  namespace: default
   labels:
     helm.sh/chart: llm-d-modelservice-v0.2.8
     app.kubernetes.io/version: "v0.2.0"
@@ -518,7 +518,7 @@ spec:
   - group: gateway.networking.k8s.io
     kind: Gateway
     name: inference-gateway
-    namespace: 'llm-d-wide-ep'
+    namespace: 'default'
   rules:
     - backendRefs:
       - group: inference.networking.x-k8s.io

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -25,7 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pvc-llm-d-modelservice-epp
-  namespace: llm-d-wide-ep
+  namespace: default
 data:
   default-config.yaml: |
     apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -312,7 +312,7 @@ metadata:
   name: pvc-llm-d-modelservice-epp
   labels:
     llm-d.ai/epp: pvc-llm-d-modelservice-epp
-  namespace: llm-d-wide-ep
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -331,7 +331,7 @@ spec:
         - --poolName
         - pvc-llm-d-modelservice
         - --poolNamespace
-        - llm-d-wide-ep
+        - default
         - -v
         - "4"
         - --zap-encoder
@@ -485,7 +485,7 @@ apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
   name: pvc-llm-d-modelservice
-  namespace: llm-d-wide-ep
+  namespace: default
 spec:
   extensionRef:
     failureMode: FailClose
@@ -502,7 +502,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: pvc-llm-d-modelservice
-  namespace: llm-d-wide-ep
+  namespace: default
   labels:
     helm.sh/chart: llm-d-modelservice-v0.2.8
     app.kubernetes.io/version: "v0.2.0"
@@ -514,7 +514,7 @@ spec:
   - group: gateway.networking.k8s.io
     kind: Gateway
     name: inference-gateway
-    namespace: 'llm-d-wide-ep'
+    namespace: 'default'
   rules:
     - backendRefs:
       - group: inference.networking.x-k8s.io


### PR DESCRIPTION
relates to: https://llm-d.slack.com/archives/C08SBNRRSBD/p1757248607514779

cc @kalantar @nirrozenbaum

Changes:
- use actual model name for model label
- enable passing apiversions for inferencepool ref in httpRoute