### PR TITLE
Add a line break at the end to render correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ Please open a ticket if you see a gap in your use case as we continue to evolve 
 
 ## Contact
 Get involved or ask questions in the `#sig-model-service` channel in the `llm-d` Slack workspace! Details on how to join the workspace can be found [here](https://llm-d.ai/docs/community).
+


### PR DESCRIPTION
We need a line break at the end of the README.md so that the footer on the website renders correctly.

https://llm-d.ai/docs/architecture/Components/modelservice

<img width="915" height="239" alt="Screenshot 2025-09-11 at 9 34 06 AM" src="https://github.com/user-attachments/assets/26d03b7d-b853-4e3a-9255-d6f2934a48af" />
