### PR TITLE
CI: Add link checker - fails PR if links are broken

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -1,0 +1,26 @@
+name: Markdown Link Checker
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  lychee:
+    name: Check Markdown Links
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install lychee v0.18.1
+        run: |
+          curl -Ls https://github.com/lycheeverse/lychee/releases/download/lychee-v0.20.1/lychee-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          sudo mv lychee /usr/local/bin
+
+      - name: Run lychee on Markdown files with config
+        run: |
+          find . -name "*.md" -print0 | xargs -0 lychee --config .lychee.toml --verbose --no-progress

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,13 @@
+# Ignore transient failures on gnu.org (it sometimes refuses connections)
+exclude = [
+  "^https://www.gnu.org/software/make/?$"
+]
+
+# Timeout in seconds
+timeout = 20
+
+# Retry failed links (helpful for flaky sites)
+retry_count = 3
+
+# Accept non-200 status codes (429: rate limits)
+accept = [200, 429]

--- a/examples/pvc/README.md
+++ b/examples/pvc/README.md
@@ -83,7 +83,7 @@ Examine [output-pvc.yaml](../output-pvc.yaml) to view the Kubernetes resources t
 
 Note that the path after the `<pvc-name>` is the path on the PVC which the downloaded files can be found. If you don't know the path, create a debug pod (see an example manifest [here](./pvc-debugger.yaml)) and exec (`k exec -it pvc-debugger -- bin/bash`) into it to find out. The path should not contain the mountPath of that debug pod. For example, if inside the pod, the path is which model files can be found is `/mnt/huggingface/cache/models/`, then use just `huggingface/cache/models/` as the `<path/to/model>` because `/mnt` is specific to the mountPath of that debug pod.
 
-Make sure that for the container of your interst in `prefill.containers` or `decode.containers`, there's a field called `mountModelVolume: true` ([see example](../values-pvc.yaml#L90)) for the volume mounts to be created correctly.
+Make sure that for the container of your interst in `prefill.containers` or `decode.containers`, there's a field called `mountModelVolume: true` ([see example](../values-pd.yaml#L87)) for the volume mounts to be created correctly.
 
 ### Behavior
 - A read-only PVC volume with the name `model-storage` is created for the deployment
@@ -118,7 +118,7 @@ helm install pvc-hf-example llm-d-modelservice/llm-d-modelservice \
 --set modelArtifacts.uri="pvc+hf://pvc-name/path/to/hf_hub_cache/facebook/opt-125m"
 ```
 
-Make sure that for the container of your interst in `prefill.containers` or `decode.containers`, there's a field called `mountModelVolume: true` ([see example](../values-pvc.yaml#L90)) for the volume mounts to be created correctly.
+Make sure that for the container of your interst in `prefill.containers` or `decode.containers`, there's a field called `mountModelVolume: true` ([see example](../values-pd.yaml#L87)) for the volume mounts to be created correctly.
 
 ### Behavior
 - A read-only PVC volume with the name `model-storage` is created for the deployment


### PR DESCRIPTION
Due to recent issues with broken links (#115), the CI system will now include a link checker that causes pull requests to fail if any broken links are detected.  
Reference: https://github.com/llm-d/llm-d-inference-scheduler/pull/130