### PR TITLE
Add Prow GitHub Actions

### DIFF
--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -1,0 +1,37 @@
+# Run specified actions or jobs for issue and PR comments
+
+name: "Prow github actions"
+on:
+  issue_comment:
+    types: [created]
+
+# Grant additional permissions to the GITHUB_TOKEN
+permissions:
+  # Allow labeling issues
+  issues: write
+  # Allow adding a review to a pull request
+  pull-requests: write
+
+jobs:
+  prow-execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          prow-commands: "/assign
+            /unassign
+            /approve
+            /retitle
+            /area
+            /kind
+            /priority
+            /remove
+            /lgtm
+            /close
+            /reopen
+            /lock
+            /milestone
+            /hold
+            /cc
+            /uncc"

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -1,0 +1,18 @@
+# This Github workflow will check every 5m for PRs with the lgtm label and will attempt to automatically merge them.
+# If the hold label is present, it will block automatic merging.
+
+name: "Prow merge on lgtm label"
+on:
+  schedule:
+  - cron: "*/5 * * * *" # every 5 minutes
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          jobs: 'lgtm'
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          merge-method: 'squash'
+

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -1,0 +1,11 @@
+name: Run Jobs on PR
+on: pull_request
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          jobs: lgtm
+          github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/re-run-action.yml
+++ b/.github/workflows/re-run-action.yml
@@ -1,0 +1,16 @@
+name: Re-Run PR tests
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun_pr_tests:
+    name: rerun_pr_tests
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: estroz/rerun-actions@main
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        comment_id: ${{ github.event.comment.id }}

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- jgchn
+- kalantar
+
+reviewers:
+- yankay


### PR DESCRIPTION
This commit adds GitHub Actions workflows for Prow CI/CD pipeline, including the following files:

- Prow GitHub workflow
- PR auto-merge workflow
- PR LGTM removal workflow
- Re-run action workflow
- Prow labels configuration
- OWNERS file
  - Please check the OWNERS file

Similar to:  https://github.com/llm-d/llm-d-inference-scheduler/pull/290