### PR TITLE
add intel HPU device

### DIFF
--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -114,7 +114,13 @@
                             "title": "intel-xe",
                             "type": "string"
                         },
-                        "nvidia": {
+                        "intel-hpu": {
+                            "default": "habana.ai/gaudi",
+                            "required": [],
+                            "title": "intel-hpu",
+                            "type": "string"
+                        },
+			"nvidia": {
                             "default": "nvidia.com/gpu",
                             "required": [],
                             "title": "nvidia",

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -42,6 +42,7 @@ accelerator:
     nvidia: "nvidia.com/gpu"
     intel-i915: "gpu.intel.com/i915"
     intel-xe: "gpu.intel.com/xe"
+    intel-hpu: "habana.ai/gaudi"
     amd: "amd.com/gpu"
     google: "google.com/tpu"
   # Environment variables specific to accelerator types


### PR DESCRIPTION
This PR is related to add Intel's HPU device for llm-d-modelservice. 

Two parts are modified for Intel's HPU definition:

1. charts/llm-d-modelservice/values.yaml and added with 
      intel-hpu: "habana.ai/gaudi"
2. charts/llm-d-modelservice/values.schema.json and added with
                       "intel-hpu": {
                            "default": "habana.ai/gaudi",
                            "required": [],
                            "title": "intel-hpu",
                            "type": "string"
                        },

The modifications above also tested another PR in llm-d side for ms-pd/values_hpu.yaml and passed. 

please review/check and welcome for any comments.

Thanks