### PR TITLE
Enable chart version checking and automated bumping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,10 @@ For every Pull Request submitted, ensure the following steps have been done:
    - `X` (major) is incremented for breaking changes,
    - `Y` (minor) is incremented when new features are added without breaking existing functionality,
    - `Z` (patch) is incremented for bug fixes, minor improvements, or non-breaking changes.
+
+   If you modify the chart, please bump the chart version. You can run `make bump-chart-version-patch` to automatically increment the patch version. After updating the chart, run `make lint` to validate your changes.
 5. Run pre-commit hooks to ensure code quality and schema validation: `make pre-commit-run`
-6. Lint tests have been run for the Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
+6. Lint tests have been run for the Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `make lint` command.
 <!-- TODO after the helm-docs supported: 7. Make sure that [helm-docs](https://github.com/norwoodj/helm-docs) has been run to generate/update the `README.md` documentation. To preview the content, use `helm-docs --dry-run`. -->
 
 ## FAQ and Troubleshooting

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ pre-helm: tools ## Set up Helm dependency repositories
 
 .PHONY: lint
 lint: pre-helm ## Run lint checks using helm-lint
-	ct lint --check-version-increment=false --validate-maintainers=false --charts charts/llm-d-modelservice $(if $(TARGET_BRANCH),--target-branch $(TARGET_BRANCH))
+	ct lint --config ct.yaml $(if $(TARGET_BRANCH),--target-branch $(TARGET_BRANCH))
 
 # Paths that need verification during 'make verify'
 PATHS_TO_VERIFY := examples/
@@ -30,6 +30,13 @@ verify: generate ## Verify that generated files match current state
 
 .PHONY: generate
 generate: tools ## Generate example output files from Helm chart templates
+	hack/generate-example-output.sh
+
+.PHONY: bump-chart-version-%
+bump-chart-version-%: tools ## Bump chart version by type (patch, major, minor) e.g., make bump-chart-version-patch
+	@printf "\033[33;1m==== Running bump chart version ====\033[0m\n"
+	hack/increment-chart-version.sh $*
+	## Regenerate example output after version bump
 	hack/generate-example-output.sh
 
 ##@ Tools

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,7 @@
+chart-dirs:
+  - charts
+validate-maintainers: false
+remote: origin
+helm-extra-args: --timeout 500s
+lint-conf: lintconf.yaml
+chart-yaml-schema: chart_schema.yaml

--- a/hack/increment-chart-version.sh
+++ b/hack/increment-chart-version.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <bump_type>
+
+Bumps the Helm chart version in Chart.yaml by the specified type.
+
+Required argument:
+  bump_type     The type of version bump. Must be one of:
+                  - major
+                  - minor
+                  - patch
+
+Examples:
+  $(basename "$0") patch     # 1.2.3 -> 1.2.4
+  $(basename "$0") minor     # 1.2.3 -> 1.3.0
+  $(basename "$0") major     # 1.2.3 -> 2.0.0
+
+EOF
+  exit 1
+}
+
+BUMP_TYPE="$1"
+
+if [[ -z "${BUMP_TYPE}" ]]; then
+  echo -e "Error: no \$bump_type passed as \$1.\n"
+  usage
+elif [[ "${BUMP_TYPE}" != "major" ]] && [[ "${BUMP_TYPE}" != "minor" ]] && [[ "${BUMP_TYPE}" != "patch" ]]; then
+  echo -e "Error: \$bump_type \"${BUMP_TYPE}\" not recognized.\n"
+  usage
+fi
+
+# requires git, yq
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Path to your Chart.yaml
+CHART_FILE="charts/llm-d-modelservice/Chart.yaml"
+CHART_PATH="${REPO_ROOT}/${CHART_FILE}"
+
+current_version=$(yq e '.version' "${CHART_PATH}")
+
+echo "Current version: $current_version"
+
+IFS='.' read -r major minor patch <<< "$current_version"
+
+if [[ "${BUMP_TYPE}" == "patch" ]]; then
+  patch=$((patch + 1))
+elif [[ "${BUMP_TYPE}" == "minor" ]]; then
+  minor=$((minor + 1))
+  patch=0
+elif [[ "${BUMP_TYPE}" == "major" ]]; then
+  major=$((major + 1))
+  minor=0
+  patch=0
+fi
+
+new_version="$major.$minor.$patch"
+
+yq e -i ".version = \"$new_version\"" "$CHART_PATH"
+
+echo "Version updated: $current_version → $new_version"


### PR DESCRIPTION
fix: #137

This PR enables automated chart version checking and bumping functionality for the Helm chart.
The same in [llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra/). Additionally, use the script like [`/increment-chart-version.sh`.
](https://github.com/llm-d-incubation/llm-d-infra/blob/main/helpers/scripts/increment-chart-version.sh)

## Usage

After modifying the chart, contributors can now run `make bump-chart-version-patch` (or minor/major) to automatically increment the version and regenerate examples. The `make lint` command now uses the centralized config for consistent validation.

