### PR TITLE
add serviceAccountOverride

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "v0.3.2"
+version: "v0.3.3"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -195,11 +195,6 @@ resources:
     {{- toYaml $requests | nindent 4 }}
 {{- end }}
 
-{{/* EPP name */}}
-{{- define "llm-d-modelservice.eppName" -}}
-{{ include "llm-d-modelservice.fullname" . }}-epp
-{{- end }}
-
 {{/* prefill name */}}
 {{- define "llm-d-modelservice.prefillName" -}}
 {{ include "llm-d-modelservice.fullname" . }}-prefill
@@ -212,7 +207,11 @@ resources:
 
 {{/* P/D service account name */}}
 {{- define "llm-d-modelservice.pdServiceAccountName" -}}
+{{- if or .Values.serviceAccountOverride -}}
+{{ .Values.serviceAccountOverride }}
+{{- else -}}
 {{ include "llm-d-modelservice.fullname" . }}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/llm-d-modelservice/templates/serviceaccount.yaml
+++ b/charts/llm-d-modelservice/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.prefill .Values.decode -}}
+{{- if and (not .Values.serviceAccountOverride) (or .Values.prefill .Values.decode) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -781,6 +781,12 @@
             },
             "required": [],
             "title": "routing"
+        },
+        "serviceAccountOverride": {
+            "default": "",
+            "description": "Override to default pod serviceAccountName",
+            "required": [],
+            "title": "serviceAccountOverride"
         }
     },
     "required": [],

--- a/charts/llm-d-modelservice/values.schema.tmpl.json
+++ b/charts/llm-d-modelservice/values.schema.tmpl.json
@@ -781,6 +781,12 @@
       },
       "required": [],
       "title": "routing"
+    },
+    "serviceAccountOverride": {
+      "default": "",
+      "description": "Override to default pod serviceAccountName",
+      "required": [],
+      "title": "serviceAccountOverride"
     }
   },
   "required": [],

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -13,6 +13,9 @@ enabled: true
 # -- String to fully override common.names.fullname
 fullnameOverride: ""
 
+# -- Override to default pod serviceAccountName
+serviceAccountOverride: ""
+
 # schedulerName -- Name of the scheduler to use for scheduling model pods
 # schedulerName: default-scheduler
 

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -99,7 +99,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-dra.yaml
+++ b/examples/output-dra.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: dra-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: dra-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -121,7 +121,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -121,7 +121,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -119,7 +119,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.3.2
+    helm.sh/chart: llm-d-modelservice-v0.3.3
     app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:


### PR DESCRIPTION
Fixes https://github.com/llm-d-incubation/llm-d-modelservice/issues/152.
If `serviceAccountOverride` is specified, it is used in the prefill and decode pods. In this case, no `ServiceAccount` is created.