### PR TITLE
fix: allow write access for pvc+hf protocol

### DIFF
--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -349,7 +349,7 @@ volumeMounts:
 {{- $protocol := first $parsedArtifacts -}}
 {{- $path := last $parsedArtifacts -}}
 {{- if or (eq $protocol "oci") (eq $protocol "pvc") }}
-    readOnly: {{ if eq $protocol "pvc+hf" }}false{{ else }}true{{ end }}
+    readOnly: true
 {{- end -}}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The pvc+hf:// protocol is designed to use a local HuggingFace cache directory via PVC. However, HuggingFace's hub library needs write access to the cache directory for metadata files and potential model downloads.

This change makes pvc+hf protocol use readOnly: false while keeping
pvc:// and oci:// protocols as readOnly: true for security.

Fixes: OSError: [Errno 30] Read-only file system: '/model-cache/hub'