### PR TITLE
add hostNetwork option for gpudirect rdma connection

### DIFF
--- a/charts/llm-d-modelservice/templates/decode-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/decode-deployment.yaml
@@ -33,6 +33,9 @@ spec:
         {{- toYaml .Values.decode.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      {{- if hasKey .Values.prefill "hostNetwork" }}
+      hostNetwork: {{ .Values.prefill.hostNetwork }}
+      {{- end }}
       {{- if .Values.decode.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.decode.nodeSelector | nindent 8 }}

--- a/charts/llm-d-modelservice/templates/prefill-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/prefill-deployment.yaml
@@ -33,6 +33,9 @@ spec:
         {{- toYaml .Values.prefill.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      {{- if hasKey .Values.prefill "hostNetwork" }}
+      hostNetwork: {{ .Values.prefill.hostNetwork }}
+      {{- end }}
       {{- if .Values.prefill.initContainers }}
       initContainers:
       {{- toYaml .Values.prefill.initContainers | nindent 8 }}


### PR DESCRIPTION
Hi community, I'm working on enabling/validating gpudirect connection between P/D on LLMD for Intel hardwares. The issue I met is that my k8s cluster cannot establish an rdma connection without passing the "hostNetwork: true". As follows:

```
# ib_write_bw -d mlx5_0 -p 8888

************************************
* Waiting for client to connect... *
************************************
---------------------------------------------------------------------------------------
                    RDMA_Write BW Test
 Dual-port       : OFF          Device         : mlx5_0
 Number of qps   : 1            Transport type : IB
 Connection type : RC           Using SRQ      : OFF
 PCIe relax order: ON
 ibv_wr* API     : ON
 CQ Moderation   : 1
 Mtu             : 2048[B]
 Link type       : Ethernet
 GID index       : 3
 Max inline data : 0[B]
 rdma_cm QPs     : OFF
 Data ex. method : Ethernet
---------------------------------------------------------------------------------------
Failed to modify QP 6814 to RTR
 Unable to Connect the HCA's through the link

# ib_write_bw x.x.x.x -d mlx5_0 -p 8888
---------------------------------------------------------------------------------------
                    RDMA_Write BW Test
 Dual-port       : OFF          Device         : mlx5_0
 Number of qps   : 1            Transport type : IB
 Connection type : RC           Using SRQ      : OFF
 PCIe relax order: ON
 ibv_wr* API     : ON
 TX depth        : 128
 CQ Moderation   : 1
 Mtu             : 2048[B]
 Link type       : Ethernet
 GID index       : 3
 Max inline data : 0[B]
 rdma_cm QPs     : OFF
 Data ex. method : Ethernet
---------------------------------------------------------------------------------------
Failed to modify QP 6811 to RTR
 Unable to Connect the HCA's through the link
```

I think the clearest way for my case is to let the k8s use the host network, which can solve that issue. However, the `hostNetwork` field is ignored when being rendered by the charts in this repo.

To test, edit the `examples/values-pd.yaml` and add the `hostNetwork: true`

```bash
--- a/examples/values-pd.yaml
+++ b/examples/values-pd.yaml
@@ -27,6 +27,7 @@ routing:
 decode:
   create: true
   replicas: 1
+  hostNetwork: true
   containers:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d:v0.2.0"
@@ -66,6 +67,7 @@ decode:
 prefill:
   create: true
   replicas: 1
+  hostNetwork: true
   containers:
   - name: "vllm"
     image: "ghcr.io/llm-d/llm-d:v0.2.0"
```

And check the template using:

```
helm template pd charts/llm-d-modelservice -f examples/values-pd.yaml
```

and the hostNetwork field is rendered correctly for the prefill/decode pod

```
...
    spec:
      hostNetwork: true
      initContainers:
...
```

Here is the small PR to fix that. Welcome to any feedback!