### PR TITLE
feat: enforce decode.enable to be true

### DIFF
--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -417,10 +417,11 @@
                     "type": "array"
                 },
                 "create": {
-                    "default": true,
+                    "const": true,
+                    "default": "true",
+                    "description": " const: true @schema",
                     "required": [],
-                    "title": "create",
-                    "type": "boolean"
+                    "title": "create"
                 },
                 "initContainers": {
                     "description": " type: array items:   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container @schema Additional init containers to run before the main containers These will be added alongside the routing proxy init container (if enabled)",

--- a/charts/llm-d-modelservice/values.schema.tmpl.json
+++ b/charts/llm-d-modelservice/values.schema.tmpl.json
@@ -417,10 +417,11 @@
           "type": "array"
         },
         "create": {
-          "default": true,
+          "const": true,
+          "default": "true",
+          "description": " const: true @schema",
           "required": [],
-          "title": "create",
-          "type": "boolean"
+          "title": "create"
         },
         "initContainers": {
           "description": " type: array items:   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container @schema Additional init containers to run before the main containers These will be added alongside the routing proxy init container (if enabled)",

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -229,6 +229,9 @@ routing:
 # @schema
 # -- Decode pod configuration
 decode:
+  # @schema
+  # const: true
+  # @schema
   create: true
   autoscaling:
     enabled: false


### PR DESCRIPTION
# changes 
- if user set `decode.enable: false `and still have `prefill.enable: true` only one prefill pod to be created, but it wont work as routing sidecar wont be running inside prefill pod.  it is better to exit with message for user to correct the value

# test
>helm template chore_3 ./charts/llm-d-modelservice --set decode.create=false 2>&1
```
Exit code 1
Error: values don't meet the specifications of the schema(s) in the following chart(s):
llm-d-modelservice:
- decode.create: decode.create does not match: true
```