### PR TITLE
update: bump version for GIE to latest 1.3.0

### DIFF
--- a/.github/workflows/lint-charts.yaml
+++ b/.github/workflows/lint-charts.yaml
@@ -58,7 +58,7 @@ jobs:
           kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
 
           # Install Kubernetes Gateway API Inference Extension CRDs
-          VERSION=v0.3.0
+          VERSION=v1.3.0
           kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$VERSION/manifests.yaml
 
       - name: Run chart-testing (install)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Once a model is deployed, inference requests must be routed to it. To do this, t
 
 Note that when using the GAIE [inferencepool chart](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/config/charts/inferencepool) together with the modelservice chart the following relationships will exist:
 
-- The modelservice field `modelArtifact.routing.servicePort` should match the GAIE field `inferencePool.targetPortNumber` or be an entry in the list `inferencePool.targets` (depending on the apiVersion of InferencePool).
+- The modelservice field `modelArtifact.routing.servicePort` should match the GAIE field `inferencePool.targetPortNumber` (for InferencePool v1alpha2) or be an entry in the list `inferencePool.targets` (for InferencePool v1).
 - The modelservice field `modelArtifact.labels` should match the GAIE field, `inferencePool.modelServers.matchLabels`.
 Note that the field `llm-d.ai/role` will be addition in addition to the labels specified in the `modelArtifacts.labels` field.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -95,7 +95,7 @@ spec:
     name: INSERT_GATEWAY_NAME
   rules:
   - backendRefs:
-    - group: inference.networking.x-k8s.io
+    - group: inference.networking.k8s.io
       kind: InferencePool
       name: INSERT_INFERENCEPOOL_NAME
       port: 8000
@@ -122,7 +122,7 @@ spec:
     name: INSERT_GATEWAY_NAME
   rules:
   - backendRefs:
-    - group: inference.networking.x-k8s.io
+    - group: inference.networking.k8s.io
       kind: InferencePool
       name: INSERT_INFERENCEPOOL_NAME
       port: 8000


### PR DESCRIPTION
# Description
- currently on 0.3.0 which is old, we should get the new one esp. API version changes in inferencepool
- this is mostly for internal GH action tests, and documentation, no real code update, thus not bump chart version