### PR TITLE
feat: add support for new field prefill.servicePort

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "v0.4.3"
+version: "v0.4.4"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -3557,7 +3557,7 @@
                 },
                 "parallelism": {
                     "additionalProperties": false,
-                    "description": "VLLM parallelism configuration",
+                    "description": "Name of the scheduler to use for scheduling prefill pods (overrides global schedulerName) schedulerName: prefill-scheduler VLLM parallelism configuration",
                     "properties": {
                         "data": {
                             "default": 1,
@@ -3585,8 +3585,7 @@
                         }
                     },
                     "required": [],
-                    "title": "parallelism",
-                    "type": "object"
+                    "title": "parallelism"
                 },
                 "replicas": {
                     "default": 0,

--- a/charts/llm-d-modelservice/values.schema.tmpl.json
+++ b/charts/llm-d-modelservice/values.schema.tmpl.json
@@ -929,7 +929,7 @@
         },
         "parallelism": {
           "additionalProperties": false,
-          "description": "VLLM parallelism configuration",
+          "description": "Name of the scheduler to use for scheduling prefill pods (overrides global schedulerName) schedulerName: prefill-scheduler VLLM parallelism configuration",
           "properties": {
             "data": {
               "default": 1,
@@ -957,8 +957,7 @@
             }
           },
           "required": [],
-          "title": "parallelism",
-          "type": "object"
+          "title": "parallelism"
         },
         "replicas": {
           "default": 0,

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -459,10 +459,16 @@ prefill:
     enabled: false
 
   replicas: 0
+
   # @schema
   # additionalProperties: true
   # @schema
   nodeSelector: {}
+
+  # Port on which the prefill vLLM container listens
+  # When not specified, falls back to routing.servicePort
+  # Uncomment to override:
+  # servicePort: 8000
   # schedulerName -- Name of the scheduler to use for scheduling prefill pods (overrides global schedulerName)
   # schedulerName: prefill-scheduler
 

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -105,7 +105,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-dra.yaml
+++ b/examples/output-dra.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: dra-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: dra-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -115,7 +115,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: intel-gaudi-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-gaudi.yaml
+++ b/examples/output-gaudi.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: gaudi-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: gaudi-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-heterogeneous-pd.yaml
+++ b/examples/output-heterogeneous-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: heterogeneous-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -131,7 +131,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -224,7 +224,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: nvidia-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-pd-mnnvl.yaml
+++ b/examples/output-pd-mnnvl.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-mnnvl-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -131,7 +131,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -127,7 +127,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -127,7 +127,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -126,7 +126,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-requester.yaml
+++ b/examples/output-requester.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: requester-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -142,7 +142,7 @@ kind: Deployment
 metadata:
   name: requester-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu-pd.yaml
+++ b/examples/output-xpu-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -158,7 +158,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu.yaml
+++ b/examples/output-xpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.3
+    helm.sh/chart: llm-d-modelservice-v0.4.4
     app.kubernetes.io/version: "v0.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/values-simple-port-pd.yaml
+++ b/examples/values-simple-port-pd.yaml
@@ -1,0 +1,66 @@
+# Simple example to show port configuration in P/D (Prefill/Decode) setup
+# when prefill and decode pods uses different service ports.
+
+modelArtifacts:
+  name: facebook/opt-125m
+  labels:
+    llm-d.ai/inferenceServing: "true"
+    llm-d.ai/model: facebook-opt-125m
+  uri: hf://facebook/opt-125m
+  size: 10Gi
+
+# Port configuration at routing level
+routing:
+  servicePort: 8000        # External service port (decode sidecar receives requests here)
+  proxy:
+    targetPort: 8200       # Internal decode port (decode main llm-d container responses here)
+
+prefill:
+  create: true
+  replicas: 1
+  servicePort: 8300         # External service port (prefill pod recieves requests here)
+  containers:
+  - name: "vllm"
+    image: "ghcr.io/llm-d/llm-d-cuda:latest"
+    modelCommand: vllmServe
+    args:
+      - "--kv-transfer-config"
+      - '{"kv_connector":"NixlConnector", "kv_role":"kv_producer"}'
+    env:
+      - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+        value: "5600"
+
+    # PREFILL PORTS: Uses servicePort (8300)
+    ports:
+      - containerPort: 8300  # Main service port for incoming requests
+        protocol: TCP
+      - containerPort: 5600  # NIXL side channel for P/D communication
+        protocol: TCP
+
+    mountModelVolume: true
+
+# Decode pod - handles token generation
+decode:
+  create: true
+  replicas: 1
+  containers:
+  - name: "vllm"
+    image: "ghcr.io/llm-d/llm-d-cuda:latest"
+    modelCommand: vllmServe
+    args:
+      - "--kv-transfer-config"
+      - '{"kv_connector":"NixlConnector", "kv_role":"kv_consumer"}'
+    env:
+      - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+        value: "5600"  # Side channel for P/D communication
+
+    # DECODE PORTS: Uses multiple ports (8000 and 8200)
+    ports:
+      - containerPort: 8000
+        protocol: TCP
+      - containerPort: 8200
+        protocol: TCP
+      - containerPort: 5600  # NIXL side channel for P/D communication
+        protocol: TCP
+
+    mountModelVolume: true


### PR DESCRIPTION
# changes
- to support prefill use a different port than decode's port
- if prefill.servicePort is not set, fall back to use routing.servicePort
- if both prefill.servicePort and prefill.container.ports are set, servicePort take precedence to be containerPorts