### PR TITLE
Update requester template to work with latest FMA

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "v0.4.12"
+version: "v0.4.13"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -486,7 +486,9 @@ context is a dict with helm root context plus:
   {{- with .container.env }}
     {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 2 }}
   {{- end }}
+  {{- if .parallelism }}
   {{- (include "llm-d-modelservice.parallelismEnv" .) | nindent 2 }}
+  {{- end }}
   {{- /* insert envs based on what modelArtifact prefix */}}
   {{- (include "llm-d-modelservice.hfEnv" .) | nindent 2 }}
   {{- /* Add accelerator-specific environment variables */}}

--- a/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
+++ b/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
@@ -1,4 +1,45 @@
 {{- if and .Values.requester.enable (and .Values.decode.create (not .Values.multinode)) }}
+---
+apiVersion: fma.llm-d.ai/v1alpha1
+kind: LauncherConfig
+metadata:
+  name: {{ .Values.requester.launcherConfig | required "requester.launcherConfig is required when requester is enabled" }}
+spec:
+  maxSleepingInstances: {{ .Values.requester.launcherConfigSpec.maxSleepingInstances | default 3 }}
+  podTemplate:
+    {{- with .Values.requester.launcherConfigSpec.podTemplate.metadata }}
+    metadata:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    spec:
+      {{- with .Values.requester.launcherConfigSpec.podTemplate.spec }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+---
+apiVersion: fma.llm-d.ai/v1alpha1
+kind: InferenceServerConfig
+metadata:
+  name: {{ .Values.requester.inferenceServerConfig }}
+spec:
+  launcherConfigName: {{ .Values.requester.launcherConfig }}
+  modelServerConfig:
+    {{- with .Values.requester.modelServerConfig.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.requester.modelServerConfig.labels }}
+    labels:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.requester.modelServerConfig.env_vars }}
+    env_vars:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if .Values.requester.modelServerConfig.options }}
+    options: {{ .Values.requester.modelServerConfig.options | quote }}
+    {{- end }}
+    port: {{ .Values.requester.modelServerConfig.port | default 8005 }}
+---
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
@@ -13,28 +54,9 @@ spec:
       labels:
         app: dp-app
       annotations:
-        dual-pod.llm-d.ai/admin-port: "{{ .Values.requester.adminPort }}"
-        dual-pod.llm-d.ai/server-patch: |
-          metadata:
-            labels: {
-              {{- $modelParts := split "/" .Values.modelArtifacts.name -}}
-              "model-reg": {{ index $modelParts._1 | quote }},
-              "model-repo": {{ index $modelParts._0 | quote }},
-              "app": null}
-          spec:
-            {{- if or (.Values.decode.initContainers) (eq .Values.routing.proxy.enabled true) }}
-            initContainers:
-            {{- (include "llm-d-modelservice.routingProxy" (dict "proxy" .Values.routing.proxy "servicePort" .Values.routing.servicePort "Values" .Values)) | nindent 12 }}
-            {{- if .Values.decode.initContainers }}
-            {{- toYaml .Values.decode.initContainers | nindent 12 }}
-            {{- end }}
-            {{- end }}
-            {{- with .Values.decode.containers }}
-            containers:
-              {{- range . }}
-              {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.decode)) | nindent 14 }}
-              {{- end }}
-            {{- end }}
+        dual-pods.llm-d.ai/admin-port: "{{ .Values.requester.adminPort }}"
+        dual-pods.llm-d.ai/accelerators: {{ .Values.requester.accelerators | quote }}
+        dual-pods.llm-d.ai/inference-server-config: {{ .Values.requester.inferenceServerConfig | required "requester.inferenceServerConfig is required" }}
     spec:
       containers:
         - name: inference-server
@@ -42,11 +64,8 @@ spec:
           imagePullPolicy: Always
           command:
           - /app/requester
-          env:
-          - name: PROBES_PORT
-            value: {{ .Values.requester.port.probes | quote }}
-          - name: SPI_PORT
-            value: {{ .Values.requester.port.spi | quote }}
+          - --logtostderr=false
+          - --log_file=/tmp/requester.log
           ports:
           - name: probes
             containerPort: {{ .Values.requester.port.probes }}

--- a/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
+++ b/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
@@ -12,8 +12,24 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{- end }}
     spec:
-      {{- with .Values.requester.launcherConfigSpec.podTemplate.spec }}
+      {{- $podSpec := omit .Values.requester.launcherConfigSpec.podTemplate.spec "containers" "volumes" }}
+      {{- with $podSpec }}
       {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.requester.launcherConfigSpec.podTemplate.spec.containers }}
+      containers:
+        {{- range . }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "launcher" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.requester.launcherConfigSpec)) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.requester.launcherConfigSpec.podTemplate.spec.volumes .Values.modelArtifacts }}
+      volumes:
+      {{- with .Values.requester.launcherConfigSpec.podTemplate.spec.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- if .Values.modelArtifacts }}
+      {{- include "llm-d-modelservice.mountModelVolumeVolumes" .Values.modelArtifacts | nindent 6 }}
+      {{- end }}
       {{- end }}
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
@@ -55,7 +71,6 @@ spec:
         app: dp-app
       annotations:
         dual-pods.llm-d.ai/admin-port: "{{ .Values.requester.adminPort }}"
-        dual-pods.llm-d.ai/accelerators: {{ .Values.requester.accelerators | quote }}
         dual-pods.llm-d.ai/inference-server-config: {{ .Values.requester.inferenceServerConfig | required "requester.inferenceServerConfig is required" }}
     spec:
       containers:

--- a/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
+++ b/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
@@ -19,7 +19,7 @@ spec:
       {{- with .Values.requester.launcherConfigSpec.podTemplate.spec.containers }}
       containers:
         {{- range . }}
-        {{- (include "llm-d-modelservice.container" (dict "role" "launcher" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.requester.launcherConfigSpec)) | nindent 8 }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "launcher" "container" . "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.requester.launcherConfigSpec)) | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- if or .Values.requester.launcherConfigSpec.podTemplate.spec.volumes .Values.modelArtifacts }}
@@ -31,6 +31,18 @@ spec:
       {{- include "llm-d-modelservice.mountModelVolumeVolumes" .Values.modelArtifacts | nindent 6 }}
       {{- end }}
       {{- end }}
+---
+apiVersion: fma.llm-d.ai/v1alpha1
+kind: LauncherPopulationPolicy
+metadata:
+  name: {{ .Values.requester.LauncherPopulationPolicy | required "requester.LauncherPopulationPolicy is required when requester is enabled" }}
+spec:
+  {{- with .Values.requester.launcherPopulationPolicySpec.enhancedNodeSelector }}
+  enhancedNodeSelector: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  countForLauncher:
+    - launcherConfigName: {{ .Values.requester.launcherConfig | required "requester.launcherConfig is required when requester is enabled" }}
+      launcherCount: {{ .Values.requester.launcherPopulationPolicySpec.launcherCount }}
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
 kind: InferenceServerConfig
@@ -60,15 +72,19 @@ apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: {{ include "llm-d-modelservice.decodeName" . }}
+  labels:
+    {{- include "llm-d-modelservice.labels" . | nindent 4 }}
 spec:
   replicas: {{ ternary .Values.decode.replicas 1 (hasKey .Values.decode "replicas") }}
   selector:
     matchLabels:
       app: dp-app
+      {{- include "llm-d-modelservice.decodelabels" . | nindent 6 }}
   template:
     metadata:
       labels:
         app: dp-app
+        {{- include "llm-d-modelservice.decodelabels" . | nindent 8 }}
       annotations:
         dual-pods.llm-d.ai/admin-port: "{{ .Values.requester.adminPort }}"
         dual-pods.llm-d.ai/inference-server-config: {{ .Values.requester.inferenceServerConfig | required "requester.inferenceServerConfig is required" }}
@@ -79,8 +95,6 @@ spec:
           imagePullPolicy: Always
           command:
           - /app/requester
-          - --logtostderr=false
-          - --log_file=/tmp/requester.log
           ports:
           - name: probes
             containerPort: {{ .Values.requester.port.probes }}

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -3517,11 +3517,6 @@
             "additionalProperties": true,
             "description": "Requester configuration part of the dual-pod solution for FMA",
             "properties": {
-                "accelerators": {
-                    "default": "GPU-0",
-                    "title": "accelerators",
-                    "type": "string"
-                },
                 "adminPort": {
                     "default": 8081,
                     "title": "adminPort",
@@ -3568,70 +3563,21 @@
                                     "title": "metadata"
                                 },
                                 "spec": {
-                                    "additionalProperties": false,
+                                    "additionalProperties": true,
+                                    "description": " additionalProperties: true @schema",
                                     "properties": {
                                         "containers": {
+                                            "description": " items:   additionalProperties: true @schema",
                                             "items": {
-                                                "anyOf": [
-                                                    {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "args": {
-                                                                "items": {
-                                                                    "anyOf": [
-                                                                        {
-                                                                            "type": "string"
-                                                                        }
-                                                                    ],
-                                                                    "required": []
-                                                                },
-                                                                "title": "args",
-                                                                "type": "array"
-                                                            },
-                                                            "command": {
-                                                                "items": {
-                                                                    "anyOf": [
-                                                                        {
-                                                                            "type": "string"
-                                                                        },
-                                                                        {
-                                                                            "type": "string"
-                                                                        }
-                                                                    ],
-                                                                    "required": []
-                                                                },
-                                                                "title": "command",
-                                                                "type": "array"
-                                                            },
-                                                            "image": {
-                                                                "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest",
-                                                                "title": "image",
-                                                                "type": "string"
-                                                            },
-                                                            "imagePullPolicy": {
-                                                                "default": "IfNotPresent",
-                                                                "title": "imagePullPolicy",
-                                                                "type": "string"
-                                                            },
-                                                            "name": {
-                                                                "default": "inference-server",
-                                                                "title": "name",
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [],
-                                                        "type": "object"
-                                                    }
-                                                ],
+                                                "additionalProperties": true,
                                                 "required": []
                                             },
-                                            "title": "containers",
-                                            "type": "array"
+                                            "required": [],
+                                            "title": "containers"
                                         }
                                     },
                                     "required": [],
-                                    "title": "spec",
-                                    "type": "object"
+                                    "title": "spec"
                                 }
                             },
                             "required": [],

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -3517,6 +3517,12 @@
             "additionalProperties": true,
             "description": "Requester configuration part of the dual-pod solution for FMA",
             "properties": {
+                "LauncherPopulationPolicy": {
+                    "default": "",
+                    "description": "Name of the LauncherPopulationPolicy resource (required when requester is enabled)",
+                    "title": "LauncherPopulationPolicy",
+                    "type": "string"
+                },
                 "adminPort": {
                     "default": 8081,
                     "title": "adminPort",
@@ -3528,7 +3534,7 @@
                     "type": "boolean"
                 },
                 "image": {
-                    "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest",
+                    "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:v0.5.1-alpha.4",
                     "title": "image",
                     "type": "string"
                 },
@@ -3567,13 +3573,182 @@
                                     "description": " additionalProperties: true @schema",
                                     "properties": {
                                         "containers": {
+                                            "items": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "command": {
+                                                                "items": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "required": []
+                                                                },
+                                                                "title": "command",
+                                                                "type": "array"
+                                                            },
+                                                            "env": {
+                                                                "items": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "additionalProperties": false,
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "default": "HF_HOME",
+                                                                                    "title": "name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "default": "/model-cache",
+                                                                                    "title": "value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [],
+                                                                            "type": "object"
+                                                                        },
+                                                                        {
+                                                                            "additionalProperties": false,
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "default": "VLLM_CACHE_ROOT",
+                                                                                    "title": "name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "default": "/model-cache",
+                                                                                    "title": "value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [],
+                                                                            "type": "object"
+                                                                        },
+                                                                        {
+                                                                            "additionalProperties": false,
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "default": "FLASHINFER_WORKSPACE_BASE",
+                                                                                    "title": "name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "default": "/model-cache",
+                                                                                    "title": "value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [],
+                                                                            "type": "object"
+                                                                        },
+                                                                        {
+                                                                            "additionalProperties": false,
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "default": "TRITON_CACHE_DIR",
+                                                                                    "title": "name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "default": "/tmmodel-cachep",
+                                                                                    "title": "value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [],
+                                                                            "type": "object"
+                                                                        },
+                                                                        {
+                                                                            "additionalProperties": false,
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "default": "XDG_CACHE_HOME",
+                                                                                    "title": "name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "default": "/model-cache",
+                                                                                    "title": "value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [],
+                                                                            "type": "object"
+                                                                        },
+                                                                        {
+                                                                            "additionalProperties": false,
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "default": "XDG_CONFIG_HOME",
+                                                                                    "title": "name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "default": "/model-cache",
+                                                                                    "title": "value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [],
+                                                                            "type": "object"
+                                                                        }
+                                                                    ],
+                                                                    "required": []
+                                                                },
+                                                                "title": "env",
+                                                                "type": "array"
+                                                            },
+                                                            "image": {
+                                                                "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:v0.5.1-alpha.4",
+                                                                "title": "image",
+                                                                "type": "string"
+                                                            },
+                                                            "imagePullPolicy": {
+                                                                "default": "IfNotPresent",
+                                                                "title": "imagePullPolicy",
+                                                                "type": "string"
+                                                            },
+                                                            "mountModelVolume": {
+                                                                "default": true,
+                                                                "title": "mountModelVolume",
+                                                                "type": "boolean"
+                                                            },
+                                                            "name": {
+                                                                "default": "inference-server",
+                                                                "title": "name",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "required": []
+                                            },
+                                            "title": "containers",
+                                            "type": "array"
+                                        },
+                                        "runtimeClassName": {
+                                            "default": "nvidia-legacy",
                                             "description": " items:   additionalProperties: true @schema",
                                             "items": {
                                                 "additionalProperties": true,
                                                 "required": []
                                             },
                                             "required": [],
-                                            "title": "containers"
+                                            "title": "runtimeClassName"
                                         }
                                     },
                                     "required": [],
@@ -3588,6 +3763,48 @@
                     "required": [],
                     "title": "launcherConfigSpec"
                 },
+                "launcherPopulationPolicySpec": {
+                    "additionalProperties": true,
+                    "description": " additionalProperties: true @schema",
+                    "properties": {
+                        "enhancedNodeSelector": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "labelSelector": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "matchLabels": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "nvidia.com/gpu.present": {
+                                                    "default": "true",
+                                                    "title": "nvidia.com/gpu.present",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [],
+                                            "title": "matchLabels",
+                                            "type": "object"
+                                        }
+                                    },
+                                    "required": [],
+                                    "title": "labelSelector",
+                                    "type": "object"
+                                }
+                            },
+                            "required": [],
+                            "title": "enhancedNodeSelector",
+                            "type": "object"
+                        },
+                        "launcherCount": {
+                            "default": 1,
+                            "title": "launcherCount",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [],
+                    "title": "launcherPopulationPolicySpec"
+                },
                 "modelServerConfig": {
                     "additionalProperties": true,
                     "description": " additionalProperties: true @schema",
@@ -3601,17 +3818,41 @@
                         "env_vars": {
                             "additionalProperties": true,
                             "description": " additionalProperties: true @schema",
+                            "properties": {
+                                "VLLM_LOGGING_LEVEL": {
+                                    "default": "DEBUG",
+                                    "title": "VLLM_LOGGING_LEVEL",
+                                    "type": "string"
+                                },
+                                "VLLM_SERVER_DEV_MODE": {
+                                    "default": "1",
+                                    "title": "VLLM_SERVER_DEV_MODE",
+                                    "type": "string"
+                                },
+                                "VLLM_USE_V1": {
+                                    "default": "1",
+                                    "title": "VLLM_USE_V1",
+                                    "type": "string"
+                                }
+                            },
                             "required": [],
                             "title": "env_vars"
                         },
                         "labels": {
                             "additionalProperties": true,
                             "description": " additionalProperties: true @schema",
+                            "properties": {
+                                "component": {
+                                    "default": "inference",
+                                    "title": "component",
+                                    "type": "string"
+                                }
+                            },
                             "required": [],
                             "title": "labels"
                         },
                         "options": {
-                            "default": "",
+                            "default": "--model facebook/opt-125m --served-model-name facebook/opt-125m --enforce-eager --kv-transfer-config {\"kv_connector\":\"NixlConnector\", \"kv_role\":\"kv_both\"}",
                             "title": "options",
                             "type": "string"
                         },

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -3517,6 +3517,11 @@
             "additionalProperties": true,
             "description": "Requester configuration part of the dual-pod solution for FMA",
             "properties": {
+                "accelerators": {
+                    "default": "GPU-0",
+                    "title": "accelerators",
+                    "type": "string"
+                },
                 "adminPort": {
                     "default": 8081,
                     "title": "adminPort",
@@ -3531,6 +3536,147 @@
                     "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest",
                     "title": "image",
                     "type": "string"
+                },
+                "inferenceServerConfig": {
+                    "default": "",
+                    "description": "Name of the InferenceServerConfig resource (required when requester is enabled)",
+                    "title": "inferenceServerConfig",
+                    "type": "string"
+                },
+                "launcherConfig": {
+                    "default": "",
+                    "description": "Name of the LauncherConfig resource (required when requester is enabled)",
+                    "title": "launcherConfig",
+                    "type": "string"
+                },
+                "launcherConfigSpec": {
+                    "additionalProperties": true,
+                    "description": " additionalProperties: true @schema",
+                    "properties": {
+                        "maxSleepingInstances": {
+                            "default": 3,
+                            "title": "maxSleepingInstances",
+                            "type": "integer"
+                        },
+                        "podTemplate": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "metadata": {
+                                    "additionalProperties": true,
+                                    "description": " additionalProperties: true @schema",
+                                    "required": [],
+                                    "title": "metadata"
+                                },
+                                "spec": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "containers": {
+                                            "items": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "args": {
+                                                                "items": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "required": []
+                                                                },
+                                                                "title": "args",
+                                                                "type": "array"
+                                                            },
+                                                            "command": {
+                                                                "items": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "required": []
+                                                                },
+                                                                "title": "command",
+                                                                "type": "array"
+                                                            },
+                                                            "image": {
+                                                                "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest",
+                                                                "title": "image",
+                                                                "type": "string"
+                                                            },
+                                                            "imagePullPolicy": {
+                                                                "default": "IfNotPresent",
+                                                                "title": "imagePullPolicy",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "default": "inference-server",
+                                                                "title": "name",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "required": []
+                                            },
+                                            "title": "containers",
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [],
+                                    "title": "spec",
+                                    "type": "object"
+                                }
+                            },
+                            "required": [],
+                            "title": "podTemplate",
+                            "type": "object"
+                        }
+                    },
+                    "required": [],
+                    "title": "launcherConfigSpec"
+                },
+                "modelServerConfig": {
+                    "additionalProperties": true,
+                    "description": " additionalProperties: true @schema",
+                    "properties": {
+                        "annotations": {
+                            "additionalProperties": true,
+                            "description": " additionalProperties: true @schema",
+                            "required": [],
+                            "title": "annotations"
+                        },
+                        "env_vars": {
+                            "additionalProperties": true,
+                            "description": " additionalProperties: true @schema",
+                            "required": [],
+                            "title": "env_vars"
+                        },
+                        "labels": {
+                            "additionalProperties": true,
+                            "description": " additionalProperties: true @schema",
+                            "required": [],
+                            "title": "labels"
+                        },
+                        "options": {
+                            "default": "",
+                            "title": "options",
+                            "type": "string"
+                        },
+                        "port": {
+                            "default": 8005,
+                            "title": "port",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [],
+                    "title": "modelServerConfig"
                 },
                 "port": {
                     "additionalProperties": false,

--- a/charts/llm-d-modelservice/values.schema.tmpl.json
+++ b/charts/llm-d-modelservice/values.schema.tmpl.json
@@ -889,6 +889,11 @@
       "additionalProperties": true,
       "description": "Requester configuration part of the dual-pod solution for FMA",
       "properties": {
+        "accelerators": {
+          "default": "GPU-0",
+          "title": "accelerators",
+          "type": "string"
+        },
         "adminPort": {
           "default": 8081,
           "title": "adminPort",
@@ -903,6 +908,147 @@
           "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest",
           "title": "image",
           "type": "string"
+        },
+        "inferenceServerConfig": {
+          "default": "",
+          "description": "Name of the InferenceServerConfig resource (required when requester is enabled)",
+          "title": "inferenceServerConfig",
+          "type": "string"
+        },
+        "launcherConfig": {
+          "default": "",
+          "description": "Name of the LauncherConfig resource (required when requester is enabled)",
+          "title": "launcherConfig",
+          "type": "string"
+        },
+        "launcherConfigSpec": {
+          "additionalProperties": true,
+          "description": " additionalProperties: true @schema",
+          "properties": {
+            "maxSleepingInstances": {
+              "default": 3,
+              "title": "maxSleepingInstances",
+              "type": "integer"
+            },
+            "podTemplate": {
+              "additionalProperties": false,
+              "properties": {
+                "metadata": {
+                  "additionalProperties": true,
+                  "description": " additionalProperties: true @schema",
+                  "required": [],
+                  "title": "metadata"
+                },
+                "spec": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "containers": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "required": []
+                                },
+                                "title": "args",
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "required": []
+                                },
+                                "title": "command",
+                                "type": "array"
+                              },
+                              "image": {
+                                "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest",
+                                "title": "image",
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "default": "IfNotPresent",
+                                "title": "imagePullPolicy",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "inference-server",
+                                "title": "name",
+                                "type": "string"
+                              }
+                            },
+                            "required": [],
+                            "type": "object"
+                          }
+                        ],
+                        "required": []
+                      },
+                      "title": "containers",
+                      "type": "array"
+                    }
+                  },
+                  "required": [],
+                  "title": "spec",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "podTemplate",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "launcherConfigSpec"
+        },
+        "modelServerConfig": {
+          "additionalProperties": true,
+          "description": " additionalProperties: true @schema",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": " additionalProperties: true @schema",
+              "required": [],
+              "title": "annotations"
+            },
+            "env_vars": {
+              "additionalProperties": true,
+              "description": " additionalProperties: true @schema",
+              "required": [],
+              "title": "env_vars"
+            },
+            "labels": {
+              "additionalProperties": true,
+              "description": " additionalProperties: true @schema",
+              "required": [],
+              "title": "labels"
+            },
+            "options": {
+              "default": "",
+              "title": "options",
+              "type": "string"
+            },
+            "port": {
+              "default": 8005,
+              "title": "port",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "title": "modelServerConfig"
         },
         "port": {
           "additionalProperties": false,

--- a/charts/llm-d-modelservice/values.schema.tmpl.json
+++ b/charts/llm-d-modelservice/values.schema.tmpl.json
@@ -889,11 +889,6 @@
       "additionalProperties": true,
       "description": "Requester configuration part of the dual-pod solution for FMA",
       "properties": {
-        "accelerators": {
-          "default": "GPU-0",
-          "title": "accelerators",
-          "type": "string"
-        },
         "adminPort": {
           "default": 8081,
           "title": "adminPort",
@@ -940,70 +935,21 @@
                   "title": "metadata"
                 },
                 "spec": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
+                  "description": " additionalProperties: true @schema",
                   "properties": {
                     "containers": {
+                      "description": " items:   additionalProperties: true @schema",
                       "items": {
-                        "anyOf": [
-                          {
-                            "additionalProperties": false,
-                            "properties": {
-                              "args": {
-                                "items": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    }
-                                  ],
-                                  "required": []
-                                },
-                                "title": "args",
-                                "type": "array"
-                              },
-                              "command": {
-                                "items": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "string"
-                                    }
-                                  ],
-                                  "required": []
-                                },
-                                "title": "command",
-                                "type": "array"
-                              },
-                              "image": {
-                                "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest",
-                                "title": "image",
-                                "type": "string"
-                              },
-                              "imagePullPolicy": {
-                                "default": "IfNotPresent",
-                                "title": "imagePullPolicy",
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "inference-server",
-                                "title": "name",
-                                "type": "string"
-                              }
-                            },
-                            "required": [],
-                            "type": "object"
-                          }
-                        ],
+                        "additionalProperties": true,
                         "required": []
                       },
-                      "title": "containers",
-                      "type": "array"
+                      "required": [],
+                      "title": "containers"
                     }
                   },
                   "required": [],
-                  "title": "spec",
-                  "type": "object"
+                  "title": "spec"
                 }
               },
               "required": [],

--- a/charts/llm-d-modelservice/values.schema.tmpl.json
+++ b/charts/llm-d-modelservice/values.schema.tmpl.json
@@ -889,6 +889,12 @@
       "additionalProperties": true,
       "description": "Requester configuration part of the dual-pod solution for FMA",
       "properties": {
+        "LauncherPopulationPolicy": {
+          "default": "",
+          "description": "Name of the LauncherPopulationPolicy resource (required when requester is enabled)",
+          "title": "LauncherPopulationPolicy",
+          "type": "string"
+        },
         "adminPort": {
           "default": 8081,
           "title": "adminPort",
@@ -900,7 +906,7 @@
           "type": "boolean"
         },
         "image": {
-          "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest",
+          "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:v0.5.1-alpha.4",
           "title": "image",
           "type": "string"
         },
@@ -939,13 +945,182 @@
                   "description": " additionalProperties: true @schema",
                   "properties": {
                     "containers": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "required": []
+                                },
+                                "title": "command",
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "name": {
+                                          "default": "HF_HOME",
+                                          "title": "name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "default": "/model-cache",
+                                          "title": "value",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "name": {
+                                          "default": "VLLM_CACHE_ROOT",
+                                          "title": "name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "default": "/model-cache",
+                                          "title": "value",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "name": {
+                                          "default": "FLASHINFER_WORKSPACE_BASE",
+                                          "title": "name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "default": "/model-cache",
+                                          "title": "value",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "name": {
+                                          "default": "TRITON_CACHE_DIR",
+                                          "title": "name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "default": "/tmmodel-cachep",
+                                          "title": "value",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "name": {
+                                          "default": "XDG_CACHE_HOME",
+                                          "title": "name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "default": "/model-cache",
+                                          "title": "value",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "name": {
+                                          "default": "XDG_CONFIG_HOME",
+                                          "title": "name",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "default": "/model-cache",
+                                          "title": "value",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [],
+                                      "type": "object"
+                                    }
+                                  ],
+                                  "required": []
+                                },
+                                "title": "env",
+                                "type": "array"
+                              },
+                              "image": {
+                                "default": "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:v0.5.1-alpha.4",
+                                "title": "image",
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "default": "IfNotPresent",
+                                "title": "imagePullPolicy",
+                                "type": "string"
+                              },
+                              "mountModelVolume": {
+                                "default": true,
+                                "title": "mountModelVolume",
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "default": "inference-server",
+                                "title": "name",
+                                "type": "string"
+                              }
+                            },
+                            "required": [],
+                            "type": "object"
+                          }
+                        ],
+                        "required": []
+                      },
+                      "title": "containers",
+                      "type": "array"
+                    },
+                    "runtimeClassName": {
+                      "default": "nvidia-legacy",
                       "description": " items:   additionalProperties: true @schema",
                       "items": {
                         "additionalProperties": true,
                         "required": []
                       },
                       "required": [],
-                      "title": "containers"
+                      "title": "runtimeClassName"
                     }
                   },
                   "required": [],
@@ -960,6 +1135,48 @@
           "required": [],
           "title": "launcherConfigSpec"
         },
+        "launcherPopulationPolicySpec": {
+          "additionalProperties": true,
+          "description": " additionalProperties: true @schema",
+          "properties": {
+            "enhancedNodeSelector": {
+              "additionalProperties": false,
+              "properties": {
+                "labelSelector": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "matchLabels": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "nvidia.com/gpu.present": {
+                          "default": "true",
+                          "title": "nvidia.com/gpu.present",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "matchLabels",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "labelSelector",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "enhancedNodeSelector",
+              "type": "object"
+            },
+            "launcherCount": {
+              "default": 1,
+              "title": "launcherCount",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "title": "launcherPopulationPolicySpec"
+        },
         "modelServerConfig": {
           "additionalProperties": true,
           "description": " additionalProperties: true @schema",
@@ -973,17 +1190,41 @@
             "env_vars": {
               "additionalProperties": true,
               "description": " additionalProperties: true @schema",
+              "properties": {
+                "VLLM_LOGGING_LEVEL": {
+                  "default": "DEBUG",
+                  "title": "VLLM_LOGGING_LEVEL",
+                  "type": "string"
+                },
+                "VLLM_SERVER_DEV_MODE": {
+                  "default": "1",
+                  "title": "VLLM_SERVER_DEV_MODE",
+                  "type": "string"
+                },
+                "VLLM_USE_V1": {
+                  "default": "1",
+                  "title": "VLLM_USE_V1",
+                  "type": "string"
+                }
+              },
               "required": [],
               "title": "env_vars"
             },
             "labels": {
               "additionalProperties": true,
               "description": " additionalProperties: true @schema",
+              "properties": {
+                "component": {
+                  "default": "inference",
+                  "title": "component",
+                  "type": "string"
+                }
+              },
               "required": [],
               "title": "labels"
             },
             "options": {
-              "default": "",
+              "default": "--model facebook/opt-125m --served-model-name facebook/opt-125m --enforce-eager --kv-transfer-config {\"kv_connector\":\"NixlConnector\", \"kv_role\":\"kv_both\"}",
               "title": "options",
               "type": "string"
             },

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -164,12 +164,14 @@ accelerator:
 # -- Requester configuration part of the dual-pod solution for FMA
 requester:
   enable: false
-  image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest"
+  image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:v0.5.1-alpha.4"
   adminPort: 8081
   # Name of the InferenceServerConfig resource (required when requester is enabled)
   inferenceServerConfig: ""
   # Name of the LauncherConfig resource (required when requester is enabled)
   launcherConfig: ""
+  # Name of the LauncherPopulationPolicy resource (required when requester is enabled)
+  LauncherPopulationPolicy: ""
   port:
     probes: 8080
     spi: 8081
@@ -201,15 +203,40 @@ requester:
         # items:
         #   additionalProperties: true
         # @schema
+        runtimeClassName: nvidia-legacy
         containers:
           - name: inference-server
-            image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest"
+            image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:v0.5.1-alpha.4"
             imagePullPolicy: IfNotPresent
+            mountModelVolume: true
+            env:
+              - name: HF_HOME
+                value: "/model-cache"
+              - name: VLLM_CACHE_ROOT
+                value: "/model-cache"
+              - name: FLASHINFER_WORKSPACE_BASE
+                value: "/model-cache"
+              - name: TRITON_CACHE_DIR
+                value: "/tmmodel-cachep"
+              - name: XDG_CACHE_HOME
+                value: "/model-cache"
+              - name: XDG_CONFIG_HOME
+                value: "/model-cache"
             command:
               - /app/launcher.py
               - --host=0.0.0.0
               - --log-level=info
               - --port=8001
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  launcherPopulationPolicySpec:
+    enhancedNodeSelector:
+      labelSelector:
+        matchLabels:
+          nvidia.com/gpu.present: "true"
+    launcherCount: 1
 
   # @schema
   # additionalProperties: true
@@ -222,12 +249,16 @@ requester:
     # @schema
     # additionalProperties: true
     # @schema
-    labels: {}
+    labels:
+      component: inference
     # @schema
     # additionalProperties: true
     # @schema
-    env_vars: {}
-    options: ""
+    env_vars:
+      VLLM_SERVER_DEV_MODE: "1"
+      VLLM_USE_V1: "1"
+      VLLM_LOGGING_LEVEL: "DEBUG"
+    options: "--model facebook/opt-125m --served-model-name facebook/opt-125m --enforce-eager --kv-transfer-config {\"kv_connector\":\"NixlConnector\", \"kv_role\":\"kv_both\"}"
     port: 8005
 
 # Describe routing requirements. In addition to service level routing (OpenAI model name, service port)

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -166,7 +166,6 @@ requester:
   enable: false
   image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest"
   adminPort: 8081
-  accelerators: "GPU-0"
   # Name of the InferenceServerConfig resource (required when requester is enabled)
   inferenceServerConfig: ""
   # Name of the LauncherConfig resource (required when requester is enabled)
@@ -194,7 +193,14 @@ requester:
       # additionalProperties: true
       # @schema
       metadata: {}
+      # @schema
+      # additionalProperties: true
+      # @schema
       spec:
+        # @schema
+        # items:
+        #   additionalProperties: true
+        # @schema
         containers:
           - name: inference-server
             image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest"

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -166,17 +166,64 @@ requester:
   enable: false
   image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest"
   adminPort: 8081
+  accelerators: "GPU-0"
+  # Name of the InferenceServerConfig resource (required when requester is enabled)
+  inferenceServerConfig: ""
+  # Name of the LauncherConfig resource (required when requester is enabled)
+  launcherConfig: ""
   port:
     probes: 8080
     spi: 8081
   readinessProbe:
     initialDelaySeconds: 2
     periodSeconds: 5
+
   resources:
     limits:
       gpus: 1
       cpus: 1
       memory: 250Mi
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  launcherConfigSpec:
+    maxSleepingInstances: 3
+    podTemplate:
+      # @schema
+      # additionalProperties: true
+      # @schema
+      metadata: {}
+      spec:
+        containers:
+          - name: inference-server
+            image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest"
+            imagePullPolicy: IfNotPresent
+            command:
+              - /bin/bash
+              - -c
+            args:
+              - |
+                uvicorn launcher:app --host 0.0.0.0 --log-level info --port 8001
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  modelServerConfig:
+    # @schema
+    # additionalProperties: true
+    # @schema
+    annotations: {}
+    # @schema
+    # additionalProperties: true
+    # @schema
+    labels: {}
+    # @schema
+    # additionalProperties: true
+    # @schema
+    env_vars: {}
+    options: ""
+    port: 8005
 
 # Describe routing requirements. In addition to service level routing (OpenAI model name, service port)
 # also describes elements for Gateway API Inference Extension configuration

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -206,11 +206,10 @@ requester:
             image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest"
             imagePullPolicy: IfNotPresent
             command:
-              - /bin/bash
-              - -c
-            args:
-              - |
-                uvicorn launcher:app --host 0.0.0.0 --log-level info --port 8001
+              - /app/launcher.py
+              - --host=0.0.0.0
+              - --log-level=info
+              - --port=8001
 
   # @schema
   # additionalProperties: true

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-dra.yaml
+++ b/examples/output-dra.yaml
@@ -43,7 +43,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: model-pvc
-            readOnly: true
+            readOnly: false
       resourceClaims:
         - name: intel-gaudi-decode-claim
           resourceClaimTemplateName: intel-gaudi-claim-template-decode

--- a/examples/output-dra.yaml
+++ b/examples/output-dra.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: dra-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: dra-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -43,7 +43,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: model-pvc
-            readOnly: false
+            readOnly: true
       resourceClaims:
         - name: intel-gaudi-decode-claim
           resourceClaimTemplateName: intel-gaudi-claim-template-decode
@@ -116,7 +116,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: intel-gaudi-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-gaudi.yaml
+++ b/examples/output-gaudi.yaml
@@ -43,7 +43,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: model-pvc
-            readOnly: true
+            readOnly: false
       
       containers:
         - name: vllm

--- a/examples/output-gaudi.yaml
+++ b/examples/output-gaudi.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: gaudi-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: gaudi-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -43,7 +43,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: model-pvc
-            readOnly: false
+            readOnly: true
       
       containers:
         - name: vllm

--- a/examples/output-heterogeneous-pd.yaml
+++ b/examples/output-heterogeneous-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: heterogeneous-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,7 +132,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -225,7 +225,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: nvidia-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-pd-mnnvl.yaml
+++ b/examples/output-pd-mnnvl.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-mnnvl-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,7 +132,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -128,7 +128,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -62,7 +62,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: pvc-name
-            readOnly: true
+            readOnly: false
       
       containers:
         - name: vllm
@@ -156,7 +156,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: pvc-name
-            readOnly: true
+            readOnly: false
       
       containers:
         - name: vllm

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -62,7 +62,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: pvc-name
-            readOnly: false
+            readOnly: true
       
       containers:
         - name: vllm
@@ -129,7 +129,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -156,7 +156,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: pvc-name
-            readOnly: false
+            readOnly: true
       
       containers:
         - name: vllm

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -62,7 +62,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: pvc-name
-            readOnly: false
+            readOnly: true
       
       containers:
         - name: vllm
@@ -119,7 +119,7 @@ spec:
           volumeMounts:
             - name: model-storage
               mountPath: /model-cache
-              readOnly: false
+              readOnly: true
 ---
 # Source: llm-d-modelservice/templates/prefill-deployment.yaml
 apiVersion: apps/v1
@@ -127,7 +127,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -154,7 +154,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: pvc-name
-            readOnly: false
+            readOnly: true
       
       containers:
         - name: vllm
@@ -211,4 +211,4 @@ spec:
           volumeMounts:
             - name: model-storage
               mountPath: /model-cache
-              readOnly: false
+              readOnly: true

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -62,7 +62,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: pvc-name
-            readOnly: true
+            readOnly: false
       
       containers:
         - name: vllm
@@ -119,7 +119,7 @@ spec:
           volumeMounts:
             - name: model-storage
               mountPath: /model-cache
-              readOnly: true
+              readOnly: false
 ---
 # Source: llm-d-modelservice/templates/prefill-deployment.yaml
 apiVersion: apps/v1
@@ -154,7 +154,7 @@ spec:
         - name: model-storage
           persistentVolumeClaim:
             claimName: pvc-name
-            readOnly: true
+            readOnly: false
       
       containers:
         - name: vllm
@@ -211,4 +211,4 @@ spec:
           volumeMounts:
             - name: model-storage
               mountPath: /model-cache
-              readOnly: true
+              readOnly: false

--- a/examples/output-rebellions-atom.yaml
+++ b/examples/output-rebellions-atom.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: rebellions-atom-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: rebellions-atom-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-requester.yaml
+++ b/examples/output-requester.yaml
@@ -25,89 +25,9 @@ spec:
       labels:
         app: dp-app
       annotations:
-        dual-pod.llm-d.ai/admin-port: "8081"
-        dual-pod.llm-d.ai/server-patch: |
-          metadata:
-            labels: {"model-reg": "opt-125m",
-              "model-repo": "facebook",
-              "app": null}
-          spec:
-            initContainers:
-            - name: routing-proxy
-              args:
-                - --port=8000
-                - --vllm-port=8200
-                - --connector=nixlv2
-                - --zap-encoder=json
-                - --zap-log-level=debug
-                - --secure-proxy=false
-              image: ghcr.io/llm-d/llm-d-routing-sidecar:latest
-              imagePullPolicy: Always
-              env:
-              ports:
-                - containerPort: 8000
-              resources: {}
-              restartPolicy: Always
-              securityContext:
-                allowPrivilegeEscalation: false
-                runAsNonRoot: true
-            containers:
-              - name: vllm
-                image: ghcr.io/llm-d/llm-d-cuda:latest
-                
-                command: ["vllm", "serve"]
-                args:
-                  - "facebook/opt-125m"
-                  - --port
-                  - "8200"
-                  - --served-model-name
-                  - "facebook/opt-125m"
-                  
-                  
-                  - --enforce-eager
-                  - --kv-transfer-config
-                  - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
-                env:
-                - name: CUDA_VISIBLE_DEVICES
-                  value: "0"
-                - name: UCX_TLS
-                  value: cuda_ipc,cuda_copy,tcp
-                - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.podIP
-                - name: VLLM_NIXL_SIDE_CHANNEL_PORT
-                  value: "5600"
-                - name: VLLM_LOGGING_LEVEL
-                  value: DEBUG
-                - name: DP_SIZE
-                  value: "1"
-                - name: TP_SIZE
-                  value: "1"
-                - name: DP_SIZE_LOCAL
-                  value: "1"
-                
-                - name: HF_HOME
-                  value: /model-cache
-                
-                ports:
-                - containerPort: 8200
-                  protocol: TCP
-                - containerPort: 5600
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: "16"
-                    memory: 16Gi
-                    nvidia.com/gpu: "1"
-                  requests:
-                    cpu: "16"
-                    memory: 16Gi
-                    nvidia.com/gpu: "1"
-                
-                volumeMounts:
-                  - name: model-storage
-                    mountPath: /model-cache
+        dual-pods.llm-d.ai/admin-port: "8081"
+        dual-pods.llm-d.ai/accelerators: "GPU-0"
+        dual-pods.llm-d.ai/inference-server-config: inference-server-config-example
     spec:
       containers:
         - name: inference-server
@@ -115,11 +35,8 @@ spec:
           imagePullPolicy: Always
           command:
           - /app/requester
-          env:
-          - name: PROBES_PORT
-            value: "8080"
-          - name: SPI_PORT
-            value: "8081"
+          - --logtostderr=false
+          - --log_file=/tmp/requester.log
           ports:
           - name: probes
             containerPort: 8080
@@ -229,3 +146,47 @@ spec:
           volumeMounts:
             - name: model-storage
               mountPath: /model-cache
+---
+# Source: llm-d-modelservice/templates/decode-requester-replicaset.yaml
+apiVersion: fma.llm-d.ai/v1alpha1
+kind: InferenceServerConfig
+metadata:
+  name: inference-server-config-example
+spec:
+  launcherConfigName: launcher-config-example
+  modelServerConfig:
+    labels:
+      component: inference
+    env_vars:
+      CUDA_VISIBLE_DEVICES: "0"
+      DP_SIZE: "1"
+      DP_SIZE_LOCAL: "1"
+      HF_HOME: /model-cache
+      TP_SIZE: "1"
+      UCX_TLS: cuda_ipc,cuda_copy,tcp
+      VLLM_LOGGING_LEVEL: DEBUG
+      VLLM_NIXL_SIDE_CHANNEL_PORT: "5600"
+      VLLM_SERVER_DEV_MODE: "1"
+      VLLM_USE_V1: "1"
+    options: "--model facebook/opt-125m --served-model-name facebook/opt-125m --enforce-eager --kv-transfer-config {\"kv_connector\":\"NixlConnector\", \"kv_role\":\"kv_both\"}"
+    port: 8005
+---
+# Source: llm-d-modelservice/templates/decode-requester-replicaset.yaml
+apiVersion: fma.llm-d.ai/v1alpha1
+kind: LauncherConfig
+metadata:
+  name: launcher-config-example
+spec:
+  maxSleepingInstances: 3
+  podTemplate:
+    spec:
+      containers:
+      - args:
+        - |
+          uvicorn launcher:app --host 0.0.0.0 --log-level info --port 8001
+        command:
+        - /bin/bash
+        - -c
+        image: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest
+        imagePullPolicy: IfNotPresent
+        name: inference-server

--- a/examples/output-requester.yaml
+++ b/examples/output-requester.yaml
@@ -26,7 +26,6 @@ spec:
         app: dp-app
       annotations:
         dual-pods.llm-d.ai/admin-port: "8081"
-        dual-pods.llm-d.ai/accelerators: "GPU-0"
         dual-pods.llm-d.ai/inference-server-config: inference-server-config-example
     spec:
       containers:
@@ -180,13 +179,51 @@ spec:
   maxSleepingInstances: 3
   podTemplate:
     spec:
+      runtimeClassName: nvidia-legacy
       containers:
-      - args:
-        - |
-          uvicorn launcher:app --host 0.0.0.0 --log-level info --port 8001
-        command:
-        - /bin/bash
-        - -c
-        image: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest
-        imagePullPolicy: IfNotPresent
-        name: inference-server
+        - name: inference-server
+          image: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest
+          imagePullPolicy: IfNotPresent
+          
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |
+              uvicorn launcher:app --host 0.0.0.0 --log-level info --port 8001
+          env:
+          - name: HOME
+            value: /model-cache
+          - name: VLLM_CACHE_ROOT
+            value: /model-cache/vllm
+          - name: FLASHINFER_WORKSPACE_DIR
+            value: /model-cache/flashinfer
+          - name: TRITON_CACHE_DIR
+            value: /model-cache/triton
+          - name: XDG_CACHE_HOME
+            value: /model-cache
+          - name: XDG_CONFIG_HOME
+            value: /model-cache/config
+          - name: DP_SIZE
+            value: "1"
+          - name: TP_SIZE
+            value: "1"
+          - name: DP_SIZE_LOCAL
+            value: "1"
+          
+          - name: HF_HOME
+            value: /model-cache
+          
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          
+          volumeMounts:
+            - name: model-storage
+              mountPath: /model-cache
+      volumes:
+      - name: model-storage
+        emptyDir:
+          sizeLimit: 20Gi

--- a/examples/output-requester.yaml
+++ b/examples/output-requester.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: requester-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -15,27 +15,35 @@ apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: requester-llm-d-modelservice-decode
+  labels:
+    helm.sh/chart: llm-d-modelservice-v0.4.13
+    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: dp-app
+      llm-d.ai/inference-serving: "true"
+      llm-d.ai/model: facebook-opt-125m
+      llm-d.ai/role: decode
   template:
     metadata:
       labels:
         app: dp-app
+        llm-d.ai/inference-serving: "true"
+        llm-d.ai/model: facebook-opt-125m
+        llm-d.ai/role: decode
       annotations:
         dual-pods.llm-d.ai/admin-port: "8081"
         dual-pods.llm-d.ai/inference-server-config: inference-server-config-example
     spec:
       containers:
         - name: inference-server
-          image: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest
+          image: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:v0.5.1-alpha.4
           imagePullPolicy: Always
           command:
           - /app/requester
-          - --logtostderr=false
-          - --log_file=/tmp/requester.log
           ports:
           - name: probes
             containerPort: 8080
@@ -59,7 +67,7 @@ kind: Deployment
 metadata:
   name: requester-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -157,14 +165,8 @@ spec:
     labels:
       component: inference
     env_vars:
-      CUDA_VISIBLE_DEVICES: "0"
-      DP_SIZE: "1"
-      DP_SIZE_LOCAL: "1"
       HF_HOME: /model-cache
-      TP_SIZE: "1"
-      UCX_TLS: cuda_ipc,cuda_copy,tcp
       VLLM_LOGGING_LEVEL: DEBUG
-      VLLM_NIXL_SIDE_CHANNEL_PORT: "5600"
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_USE_V1: "1"
     options: "--model facebook/opt-125m --served-model-name facebook/opt-125m --enforce-eager --kv-transfer-config {\"kv_connector\":\"NixlConnector\", \"kv_role\":\"kv_both\"}"
@@ -182,15 +184,14 @@ spec:
       runtimeClassName: nvidia-legacy
       containers:
         - name: inference-server
-          image: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest
+          image: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:v0.5.1-alpha.4
           imagePullPolicy: IfNotPresent
           
           command:
-            - /bin/bash
-            - -c
-          args:
-            - |
-              uvicorn launcher:app --host 0.0.0.0 --log-level info --port 8001
+            - /app/launcher.py
+            - --host=0.0.0.0
+            - --log-level=info
+            - --port=8001
           env:
           - name: HOME
             value: /model-cache
@@ -204,12 +205,6 @@ spec:
             value: /model-cache
           - name: XDG_CONFIG_HOME
             value: /model-cache/config
-          - name: DP_SIZE
-            value: "1"
-          - name: TP_SIZE
-            value: "1"
-          - name: DP_SIZE_LOCAL
-            value: "1"
           
           - name: HF_HOME
             value: /model-cache
@@ -227,3 +222,17 @@ spec:
       - name: model-storage
         emptyDir:
           sizeLimit: 20Gi
+---
+# Source: llm-d-modelservice/templates/decode-requester-replicaset.yaml
+apiVersion: fma.llm-d.ai/v1alpha1
+kind: LauncherPopulationPolicy
+metadata:
+  name: launcher-population-policy-example
+spec:
+  enhancedNodeSelector:
+    labelSelector:
+      matchLabels:
+        nvidia.com/gpu.present: "true"
+  countForLauncher:
+    - launcherConfigName: launcher-config-example
+      launcherCount: 1

--- a/examples/output-xpu-pd.yaml
+++ b/examples/output-xpu-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -159,7 +159,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu.yaml
+++ b/examples/output-xpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/values-requester.yaml
+++ b/examples/values-requester.yaml
@@ -23,6 +23,32 @@ routing:
   proxy:
     secure: false
 
+# OpenTelemetry distributed tracing configuration
+# When enabled, vLLM and routing-proxy containers will export traces to the OTLP endpoint
+tracing:
+  # -- Enable distributed tracing
+  enabled: false
+  # -- OTLP gRPC endpoint for trace export (OTel Collector in the same namespace)
+  otlpEndpoint: "http://otel-collector:4317"
+  # -- Trace sampling configuration
+  sampling:
+    # -- OpenTelemetry sampler type (e.g., "parentbased_traceidratio", "always_on", "always_off")
+    sampler: "parentbased_traceidratio"
+    # -- Sampling ratio (0.0 to 1.0). Use 1.0 for 100% sampling (demo/debug), 0.1 for 10% (production)
+    samplerArg: "1.0"
+  # -- Service name overrides for different components
+  serviceNames:
+    # -- Service name for vLLM decode instances
+    vllmDecode: "vllm-decode"
+    # -- Service name for vLLM prefill instances
+    vllmPrefill: "vllm-prefill"
+    # -- Service name for routing proxy sidecar
+    routingProxy: "routing-proxy"
+  # -- vLLM-specific tracing options
+  vllm:
+    # -- Level of trace detail collection (e.g., "all", "model", "scheduler")
+    collectDetailedTraces: "all"
+
 # @schema
 # additionalProperties: true
 # @schema
@@ -30,6 +56,9 @@ routing:
 requester:
   enable: true
   image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest"
+  accelerators: "GPU-0"
+  inferenceServerConfig: "inference-server-config-example"
+  launcherConfig: "launcher-config-example"
   port:
     probes: 8080
     spi: 8081
@@ -41,6 +70,48 @@ requester:
       gpus: 1
       cpus: 1
       memory: 250Mi
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  launcherConfigSpec:
+    maxSleepingInstances: 3
+    podTemplate:
+      spec:
+        containers:
+          - name: inference-server
+            image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest"
+            imagePullPolicy: IfNotPresent
+            command:
+              - /bin/bash
+              - -c
+            args:
+              - |
+                uvicorn launcher:app --host 0.0.0.0 --log-level info --port 8001
+
+  modelServerConfig:
+    # @schema
+    # additionalProperties: true
+    # @schema
+    annotations: {}
+    # @schema
+    # additionalProperties: true
+    # @schema
+    labels:
+      component: inference
+    env_vars:
+      VLLM_SERVER_DEV_MODE: "1"
+      VLLM_USE_V1: "1"
+      VLLM_LOGGING_LEVEL: "DEBUG"
+      CUDA_VISIBLE_DEVICES: "0"
+      UCX_TLS: "cuda_ipc,cuda_copy,tcp"
+      VLLM_NIXL_SIDE_CHANNEL_PORT: "5600"
+      DP_SIZE: "1"
+      TP_SIZE: "1"
+      DP_SIZE_LOCAL: "1"
+      HF_HOME: "/model-cache"
+    options: "--model facebook/opt-125m --served-model-name facebook/opt-125m --enforce-eager --kv-transfer-config {\"kv_connector\":\"NixlConnector\", \"kv_role\":\"kv_both\"}"
+    port: 8005
 
 # Decode pod configuation
 decode:

--- a/examples/values-requester.yaml
+++ b/examples/values-requester.yaml
@@ -23,42 +23,17 @@ routing:
   proxy:
     secure: false
 
-# OpenTelemetry distributed tracing configuration
-# When enabled, vLLM and routing-proxy containers will export traces to the OTLP endpoint
-tracing:
-  # -- Enable distributed tracing
-  enabled: false
-  # -- OTLP gRPC endpoint for trace export (OTel Collector in the same namespace)
-  otlpEndpoint: "http://otel-collector:4317"
-  # -- Trace sampling configuration
-  sampling:
-    # -- OpenTelemetry sampler type (e.g., "parentbased_traceidratio", "always_on", "always_off")
-    sampler: "parentbased_traceidratio"
-    # -- Sampling ratio (0.0 to 1.0). Use 1.0 for 100% sampling (demo/debug), 0.1 for 10% (production)
-    samplerArg: "1.0"
-  # -- Service name overrides for different components
-  serviceNames:
-    # -- Service name for vLLM decode instances
-    vllmDecode: "vllm-decode"
-    # -- Service name for vLLM prefill instances
-    vllmPrefill: "vllm-prefill"
-    # -- Service name for routing proxy sidecar
-    routingProxy: "routing-proxy"
-  # -- vLLM-specific tracing options
-  vllm:
-    # -- Level of trace detail collection (e.g., "all", "model", "scheduler")
-    collectDetailedTraces: "all"
-
 # @schema
 # additionalProperties: true
 # @schema
 # -- Requester configuration part of the dual-pod solution for FMA
 requester:
   enable: true
-  image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest"
+  image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:v0.5.1-alpha.4"
   adminPort: 8081
   inferenceServerConfig: "inference-server-config-example"
   launcherConfig: "launcher-config-example"
+  LauncherPopulationPolicy: "launcher-population-policy-example"
   port:
     probes: 8080
     spi: 8081
@@ -81,7 +56,7 @@ requester:
         runtimeClassName: nvidia-legacy
         containers:
           - name: inference-server
-            image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest"
+            image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:v0.5.1-alpha.4"
             imagePullPolicy: IfNotPresent
             mountModelVolume: true
             env:
@@ -98,12 +73,24 @@ requester:
               - name: XDG_CONFIG_HOME
                 value: "/model-cache/config"
             command:
-              - /bin/bash
-              - -c
-            args:
-              - |
-                uvicorn launcher:app --host 0.0.0.0 --log-level info --port 8001
+              - /app/launcher.py
+              - --host=0.0.0.0
+              - --log-level=info
+              - --port=8001
 
+  # @schema
+  # additionalProperties: true
+  # @schema
+  launcherPopulationPolicySpec:
+    enhancedNodeSelector:
+      labelSelector:
+        matchLabels:
+          nvidia.com/gpu.present: "true"
+    launcherCount: 1
+
+  # @schema
+  # additionalProperties: true
+  # @schema
   modelServerConfig:
     # @schema
     # additionalProperties: true
@@ -114,16 +101,13 @@ requester:
     # @schema
     labels:
       component: inference
+    # @schema
+    # additionalProperties: true
+    # @schema
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_USE_V1: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
-      CUDA_VISIBLE_DEVICES: "0"
-      UCX_TLS: "cuda_ipc,cuda_copy,tcp"
-      VLLM_NIXL_SIDE_CHANNEL_PORT: "5600"
-      DP_SIZE: "1"
-      TP_SIZE: "1"
-      DP_SIZE_LOCAL: "1"
       HF_HOME: "/model-cache"
     options: "--model facebook/opt-125m --served-model-name facebook/opt-125m --enforce-eager --kv-transfer-config {\"kv_connector\":\"NixlConnector\", \"kv_role\":\"kv_both\"}"
     port: 8005

--- a/examples/values-requester.yaml
+++ b/examples/values-requester.yaml
@@ -56,7 +56,7 @@ tracing:
 requester:
   enable: true
   image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest"
-  accelerators: "GPU-0"
+  adminPort: 8081
   inferenceServerConfig: "inference-server-config-example"
   launcherConfig: "launcher-config-example"
   port:
@@ -78,10 +78,25 @@ requester:
     maxSleepingInstances: 3
     podTemplate:
       spec:
+        runtimeClassName: nvidia-legacy
         containers:
           - name: inference-server
             image: "ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher:latest"
             imagePullPolicy: IfNotPresent
+            mountModelVolume: true
+            env:
+              - name: HOME
+                value: "/model-cache"
+              - name: VLLM_CACHE_ROOT
+                value: "/model-cache/vllm"
+              - name: FLASHINFER_WORKSPACE_DIR
+                value: "/model-cache/flashinfer"
+              - name: TRITON_CACHE_DIR
+                value: "/model-cache/triton"
+              - name: XDG_CACHE_HOME
+                value: "/model-cache"
+              - name: XDG_CONFIG_HOME
+                value: "/model-cache/config"
             command:
               - /bin/bash
               - -c


### PR DESCRIPTION
Added new resources to the requester template. They use custom CRDs that need to be pre-installed separately:

InferenceServerConfig: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/main/config/crd/fma.llm-d.ai_inferenceserverconfigs.yaml

LauncherConfig: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/main/config/crd/fma.llm-d.ai_launcherconfigs.yaml

LauncherPopulationPolicy: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/main/config/crd/fma.llm-d.ai_launcherpopulationpolicies.yaml

