### PR TITLE
Move routing-proxy from initContainers to standard containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Active scenarios supported:
 Integration with `llm-d` components:
 - Quickstart guide in `llm-d-infra` depends on ModelService
 - Flexible configuration of `llm-d-inference-scheduler` for routing
-- Features `llm-d-routing-sidecar` in P/D disaggregation
+- Features `llm-d-routing-sidecar` as a sidecar container in P/D disaggregation
 - Utilized in benchmarking experiments in `llm-d-benchmark`
 - Effortless use of `llm-d-inference-sim` for CPU-only workloads
 - Allows to use `llm-d-fast-model-actuation`. More information about the fast model loading techniques [here](https://github.com/llm-d-incubation/llm-d-fast-model-actuation)
@@ -83,7 +83,7 @@ Below are the values you can set.
 | `decode.containers[*].command`         | List of commands for the decode container.                                                                        | List[string]    | []                                          |
 | `decode.containers[*].ports`           | List of ports for the decode container.                                                                           | List[Port]      | []                                          |
 | `decode.containers[*].extraConfig`     | Extra container configuration                                                                                     | dict            | {}                                          |
-| `decode.initContainers`.               | List of initContainers that should be added (in addition to routing proxy if enabled)                             | List[Container] | N/A                                         |
+| `decode.initContainers`.               | List of initContainers that should be added to the decode pod                                                     | List[Container] | N/A                                         |
 | `decode.parallelism.tensor`            | Amount of tensor parallelism                                                                                      | int             | 1                                           |
 | `decode.parallelism.data`              | Amount of data parallelism                                                                                        | int             | 1                                           |
 | `decode.parallelism.dataLocal`         | Amount of data local parallelism                                                                                  | int             | 1                                           |

--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -91,7 +91,7 @@ affinity:
             {{- end }}
 {{- end }}
 {{- end }}
-{{/* Create the init container for the routing proxy/sidecar for decode pods */}}
+{{/* Create the container for the routing proxy/sidecar for decode pods */}}
 {{- define "llm-d-modelservice.routingProxy" -}}
 {{- if or (not (hasKey .proxy "enabled")) (ne .proxy.enabled false) -}}
 - name: routing-proxy
@@ -141,7 +141,6 @@ affinity:
   ports:
     - containerPort: {{ default 8000 .servicePort }}
   resources: {}
-  restartPolicy: Always
   securityContext:
     allowPrivilegeEscalation: false
     runAsNonRoot: true

--- a/charts/llm-d-modelservice/templates/decode-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/decode-deployment.yaml
@@ -37,12 +37,9 @@ spec:
       nodeSelector:
         {{- toYaml .Values.decode.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- if or (.Values.decode.initContainers) (eq .Values.routing.proxy.enabled true) }}
-      initContainers:
-      {{- (include "llm-d-modelservice.routingProxy" (dict "proxy" .Values.routing.proxy "servicePort" .Values.routing.servicePort "Values" .Values)) | nindent 8 }}
       {{- if .Values.decode.initContainers }}
+      initContainers:
       {{- toYaml .Values.decode.initContainers | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- if hasKey .Values.decode "enableServiceLinks" }}
       enableServiceLinks: {{ .Values.decode.enableServiceLinks }}
@@ -51,8 +48,9 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.decode.terminationGracePeriodSeconds }}
       {{- end }}
       {{- (include "llm-d-modelservice.modelPod" (dict "role" "decode" "pdSpec" .Values.decode "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 4 }}
-      {{- with .Values.decode.containers }}
       containers:
+      {{- (include "llm-d-modelservice.routingProxy" (dict "proxy" .Values.routing.proxy "servicePort" .Values.routing.servicePort "Values" .Values)) | nindent 8 }}
+      {{- with .Values.decode.containers }}
         {{- range . }}
         {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.decode)) | nindent 8 }}
         {{- end }}

--- a/charts/llm-d-modelservice/templates/decode-lws.yaml
+++ b/charts/llm-d-modelservice/templates/decode-lws.yaml
@@ -55,12 +55,9 @@ spec:
         {{- if hasKey .Values.decode "hostPID" }}
         hostPID: {{ .Values.decode.hostPID }}
         {{- end }}
-        {{- if or (.Values.decode.initContainers) (eq .Values.routing.proxy.enabled true) }}
-        initContainers:
-        {{- (include "llm-d-modelservice.routingProxy" (dict "proxy" .Values.routing.proxy "servicePort" .Values.routing.servicePort "Values" .Values)) | nindent 8 }}
         {{- if .Values.decode.initContainers }}
+        initContainers:
         {{- toYaml .Values.decode.initContainers | nindent 10 }}
-        {{- end }}
         {{- end }}
         {{- if hasKey .Values.decode "enableServiceLinks" }}
         enableServiceLinks: {{ .Values.decode.enableServiceLinks }}
@@ -69,8 +66,9 @@ spec:
         terminationGracePeriodSeconds: {{ .Values.decode.terminationGracePeriodSeconds }}
         {{- end }}
         {{ (include "llm-d-modelservice.modelPod" (dict "role" "decode" "pdSpec" .Values.decode "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 6 }}
-        {{- with .Values.decode.containers }}
         containers:
+        {{- (include "llm-d-modelservice.routingProxy" (dict "proxy" .Values.routing.proxy "servicePort" .Values.routing.servicePort "Values" .Values)) | nindent 8 }}
+        {{- with .Values.decode.containers }}
           {{- range . }}
         {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.decode)) | nindent 8 }}
           {{- end }}


### PR DESCRIPTION
The routing-proxy container must coexist with the main decode container throughout the pod's lifecycle, not just during initialization.

Additionally, because it is a regular container, Kubernetes can run Liveness and Readiness probes on the proxy. If the proxy hangs but the vLLM engine is fine, Kubernetes knows the pod is no longer "Ready" to serve traffic. initContainers do not support these continuous health checks. We can add it in future releases.
