### PR TITLE
feat: enable customizable leader/worker templates for multinode LWS

### DIFF
--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -75,6 +75,79 @@ llm-d.ai/role: prefill
 llm-d.ai/role: decode
 {{- end }}
 
+{{/* Generic split-template switch for decode/prefill */}}
+{{- define "llm-d-modelservice.pdUseSplitTemplates" -}}
+{{- $pdSpec := index .Values .role -}}
+{{- if and .Values.multinodeEnableLeader (index $pdSpec "workerTemplate") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{/* Generic worker container inheritance/override for decode/prefill */}}
+{{- define "llm-d-modelservice.pdWorkerContainers" -}}
+{{- $pdSpec := index .Values .role -}}
+{{- $workerTemplate := default (dict) $pdSpec.workerTemplate -}}
+{{- $baseContainers := default (list) $pdSpec.containers -}}
+{{- if not (hasKey $workerTemplate "containers") -}}
+{{- toYaml $baseContainers -}}
+{{- else -}}
+  {{- $overrideContainers := default (list) $workerTemplate.containers -}}
+  {{- $mergedContainers := list -}}
+  {{- $baseLen := len $baseContainers -}}
+  {{- $overrideLen := len $overrideContainers -}}
+  {{- range $i, $baseContainer := $baseContainers -}}
+    {{- if lt $i $overrideLen -}}
+      {{- $overrideContainer := index $overrideContainers $i -}}
+      {{- $mergedContainer := deepCopy $baseContainer -}}
+      {{- range $key, $value := $overrideContainer -}}
+        {{- $_ := set $mergedContainer $key (deepCopy $value) -}}
+      {{- end -}}
+      {{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+    {{- else -}}
+      {{- $mergedContainers = append $mergedContainers (deepCopy $baseContainer) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if gt $overrideLen $baseLen -}}
+    {{- range $i, $overrideContainer := $overrideContainers -}}
+      {{- if ge $i $baseLen -}}
+        {{- $mergedContainers = append $mergedContainers (deepCopy $overrideContainer) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- toYaml $mergedContainers -}}
+{{- end -}}
+{{- end }}
+
+{{/* Generic worker pdSpec inheritance/override for decode/prefill */}}
+{{- define "llm-d-modelservice.pdWorkerPdSpec" -}}
+{{- $pdSpec := index .Values .role -}}
+{{- $workerTemplate := default (dict) $pdSpec.workerTemplate -}}
+{{- $base := deepCopy $pdSpec -}}
+{{- $overrides := deepCopy $workerTemplate -}}
+{{- $merged := mergeOverwrite $base $overrides -}}
+{{- if hasKey $workerTemplate "containers" -}}
+  {{- $mergedContainers := include "llm-d-modelservice.pdWorkerContainers" . | fromYamlArray -}}
+  {{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/* Backward-compatible wrappers */}}
+{{- define "llm-d-modelservice.decodeUseSplitTemplates" -}}
+{{- include "llm-d-modelservice.pdUseSplitTemplates" (dict "Values" .Values "role" "decode") -}}
+{{- end }}
+{{- define "llm-d-modelservice.prefillUseSplitTemplates" -}}
+{{- include "llm-d-modelservice.pdUseSplitTemplates" (dict "Values" .Values "role" "prefill") -}}
+{{- end }}
+{{- define "llm-d-modelservice.decodeWorkerPdSpec" -}}
+{{- include "llm-d-modelservice.pdWorkerPdSpec" (dict "Values" .Values "role" "decode") -}}
+{{- end }}
+{{- define "llm-d-modelservice.prefillWorkerPdSpec" -}}
+{{- include "llm-d-modelservice.pdWorkerPdSpec" (dict "Values" .Values "role" "prefill") -}}
+{{- end }}
+
 {{/* Create node affinity from acceleratorTypes in Values */}}
 {{- define "llm-d-modelservice.acceleratorTypes" -}}
 {{- if .labelKey }}

--- a/charts/llm-d-modelservice/templates/decode-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/decode-deployment.yaml
@@ -50,11 +50,11 @@ spec:
       {{- if hasKey .Values.decode "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.decode.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- (include "llm-d-modelservice.modelPod" (dict "role" "decode" "pdSpec" .Values.decode "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 4 }}
+      {{- (include "llm-d-modelservice.modelPod" (dict "role" "decode" "pdSpec" .Values.decode "Values" .Values "Release" .Release "Chart" .Chart "Template" .Template)) | nindent 4 }}
       {{- with .Values.decode.containers }}
       containers:
         {{- range . }}
-        {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.decode)) | nindent 8 }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "Template" $.Template "pdSpec" $.Values.decode)) | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- if .Values.decode.tolerations }}

--- a/charts/llm-d-modelservice/templates/decode-lws.yaml
+++ b/charts/llm-d-modelservice/templates/decode-lws.yaml
@@ -24,6 +24,7 @@ metadata:
   {{- end }}
   {{- end }}
 spec:
+  {{- $useSplitTemplates := eq (include "llm-d-modelservice.decodeUseSplitTemplates" .) "true" }}
   {{- if not .Values.decode.autoscaling.enabled }}
   replicas: {{ ternary .Values.decode.replicas 1 (hasKey .Values.decode "replicas") }}
   {{- end }}
@@ -33,54 +34,58 @@ spec:
     subGroupPolicy:
     {{- toYaml .Values.decode.subGroupPolicy | nindent 6 }}
     {{- end }}
-    workerTemplate:
+    {{- $templateSpecs := list }}
+    {{- if $useSplitTemplates }}
+    {{- $workerPdSpec := include "llm-d-modelservice.decodeWorkerPdSpec" . | fromYaml }}
+    {{- $templateSpecs = list (dict "name" "leaderTemplate" "pdSpec" .Values.decode) (dict "name" "workerTemplate" "pdSpec" $workerPdSpec) }}
+    {{- else }}
+    {{- $templateSpecs = list (dict "name" "workerTemplate" "pdSpec" .Values.decode) }}
+    {{- end }}
+    {{- range $template := $templateSpecs }}
+    {{ $template.name }}:
+      {{- $pdSpec := $template.pdSpec }}
       metadata:
         labels:
-          {{- include "llm-d-modelservice.decodelabels" . | nindent 10 }}
-        {{- if or .Values.decode.subGroupExclusiveTopology .Values.decode.podAnnotations }}
+          {{- include "llm-d-modelservice.decodelabels" $ | nindent 10 }}
+        {{- if or $pdSpec.subGroupExclusiveTopology $pdSpec.podAnnotations }}
         annotations:
-        {{- if .Values.decode.subGroupExclusiveTopology }}
+        {{- if $pdSpec.subGroupExclusiveTopology }}
           leaderworkerset.sigs.k8s.io/subgroup-exclusive-topology: kubernetes.io/hostname
         {{- end }}
-        {{- if .Values.decode.podAnnotations }}
-          {{ toYaml .Values.decode.podAnnotations | nindent 10 }}
-          {{- end }}
+        {{- if $pdSpec.podAnnotations }}
+          {{ toYaml $pdSpec.podAnnotations | nindent 10 }}
+        {{- end }}
         {{- end }}
       spec:
-        {{- /* DEPRECATED; use extraConfig.hostIPC instead */ -}}
-        {{- if hasKey .Values.decode "hostIPC" }}
-        hostIPC: {{ .Values.decode.hostIPC }}
+        {{- range $field := list "hostIPC" "hostPID" "enableServiceLinks" "terminationGracePeriodSeconds" }}
+        {{- if hasKey $pdSpec $field }}
+          {{- toYaml (dict $field (index $pdSpec $field)) | nindent 8 }}
         {{- end }}
-        {{- /* DEPRECATED; use extraConfig.hostPID instead */ -}}
-        {{- if hasKey .Values.decode "hostPID" }}
-        hostPID: {{ .Values.decode.hostPID }}
         {{- end }}
-        {{- if or (.Values.decode.initContainers) (eq .Values.routing.proxy.enabled true) }}
+        {{- $addRoutingProxy := and (eq $.Values.routing.proxy.enabled true) (or (not $useSplitTemplates) (eq $template.name "leaderTemplate")) }}
+        {{- if or $pdSpec.initContainers $addRoutingProxy }}
         initContainers:
-        {{- (include "llm-d-modelservice.routingProxy" (dict "proxy" .Values.routing.proxy "servicePort" .Values.routing.servicePort "Values" .Values)) | nindent 8 }}
-        {{- if .Values.decode.initContainers }}
-        {{- toYaml .Values.decode.initContainers | nindent 10 }}
+        {{- if $addRoutingProxy }}
+        {{- (include "llm-d-modelservice.routingProxy" (dict "proxy" $.Values.routing.proxy "servicePort" $.Values.routing.servicePort "Values" $.Values)) | nindent 10 }}
+        {{- end }}
+        {{- if $pdSpec.initContainers }}
+        {{- toYaml $pdSpec.initContainers | nindent 10 }}
         {{- end }}
         {{- end }}
-        {{- if hasKey .Values.decode "enableServiceLinks" }}
-        enableServiceLinks: {{ .Values.decode.enableServiceLinks }}
-        {{- end }}
-        {{- if hasKey .Values.decode "terminationGracePeriodSeconds" }}
-        terminationGracePeriodSeconds: {{ .Values.decode.terminationGracePeriodSeconds }}
-        {{- end }}
-        {{ (include "llm-d-modelservice.modelPod" (dict "role" "decode" "pdSpec" .Values.decode "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 6 }}
-        {{- with .Values.decode.containers }}
+        {{ (include "llm-d-modelservice.modelPod" (dict "role" "decode" "pdSpec" $pdSpec "Values" $.Values "Release" $.Release "Chart" $.Chart "Template" $.Template)) | nindent 6 }}
+        {{- with $pdSpec.containers }}
         containers:
           {{- range . }}
-        {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.decode)) | nindent 8 }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $pdSpec.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "Template" $.Template "pdSpec" $pdSpec)) | nindent 8 }}
           {{- end }}
         {{- end }}
-        {{- if .Values.decode.nodeSelector }}
+        {{- if $pdSpec.nodeSelector }}
         nodeSelector:
-          {{- toYaml .Values.decode.nodeSelector | nindent 10 }}
+          {{- toYaml $pdSpec.nodeSelector | nindent 10 }}
         {{- end }}
-        {{- if .Values.decode.tolerations }}
+        {{- if $pdSpec.tolerations }}
         tolerations:
-          {{- toYaml .Values.decode.tolerations | nindent 10 }}
+          {{- toYaml $pdSpec.tolerations | nindent 10 }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
+++ b/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
@@ -32,7 +32,7 @@ spec:
             {{- with .Values.decode.containers }}
             containers:
               {{- range . }}
-              {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.decode)) | nindent 14 }}
+              {{- (include "llm-d-modelservice.container" (dict "role" "decode" "container" . "parallelism" $.Values.decode.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "Template" $.Template "pdSpec" $.Values.decode)) | nindent 14 }}
               {{- end }}
             {{- end }}
     spec:

--- a/charts/llm-d-modelservice/templates/prefill-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/prefill-deployment.yaml
@@ -43,7 +43,7 @@ spec:
       {{- if hasKey .Values.prefill "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.prefill.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- (include "llm-d-modelservice.modelPod" (dict "role" "prefill" "pdSpec" .Values.prefill "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 4 }}
+      {{- (include "llm-d-modelservice.modelPod" (dict "role" "prefill" "pdSpec" .Values.prefill "Values" .Values "Release" .Release "Chart" .Chart "Template" .Template)) | nindent 4 }}
       {{- if .Values.prefill.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.prefill.nodeSelector | nindent 8 }}
@@ -51,7 +51,7 @@ spec:
       {{- with .Values.prefill.containers }}
       containers:
         {{- range . }}
-        {{- (include "llm-d-modelservice.container" (dict "role" "prefill" "container" . "parallelism" $.Values.prefill.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.prefill)) | nindent 8 }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "prefill" "container" . "parallelism" $.Values.prefill.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "Template" $.Template "pdSpec" $.Values.prefill)) | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- if .Values.prefill.tolerations }}

--- a/charts/llm-d-modelservice/templates/prefill-lws.yaml
+++ b/charts/llm-d-modelservice/templates/prefill-lws.yaml
@@ -24,6 +24,7 @@ metadata:
   {{- end }}
   {{- end }}
 spec:
+  {{- $useSplitTemplates := eq (include "llm-d-modelservice.prefillUseSplitTemplates" .) "true" }}
   {{- if not .Values.prefill.autoscaling.enabled }}
   replicas: {{ ternary .Values.prefill.replicas 1 (hasKey .Values.prefill "replicas") }}
   {{- end }}
@@ -33,51 +34,52 @@ spec:
     subGroupPolicy:
     {{- toYaml .Values.prefill.subGroupPolicy | nindent 6 }}
     {{- end }}
-    workerTemplate:
+    {{- $templateSpecs := list }}
+    {{- if $useSplitTemplates }}
+    {{- $workerPdSpec := include "llm-d-modelservice.prefillWorkerPdSpec" . | fromYaml }}
+    {{- $templateSpecs = list (dict "name" "leaderTemplate" "pdSpec" .Values.prefill) (dict "name" "workerTemplate" "pdSpec" $workerPdSpec) }}
+    {{- else }}
+    {{- $templateSpecs = list (dict "name" "workerTemplate" "pdSpec" .Values.prefill) }}
+    {{- end }}
+    {{- range $template := $templateSpecs }}
+    {{ $template.name }}:
+      {{- $pdSpec := $template.pdSpec }}
       metadata:
         labels:
-          {{- include "llm-d-modelservice.prefilllabels" . | nindent 10 }}
-        {{- if or .Values.prefill.subGroupExclusiveTopology .Values.prefill.podAnnotations }}
+          {{- include "llm-d-modelservice.prefilllabels" $ | nindent 10 }}
+        {{- if or $pdSpec.subGroupExclusiveTopology $pdSpec.podAnnotations }}
         annotations:
-        {{- if .Values.prefill.subGroupExclusiveTopology }}
+        {{- if $pdSpec.subGroupExclusiveTopology }}
           leaderworkerset.sigs.k8s.io/subgroup-exclusive-topology: kubernetes.io/hostname
         {{- end }}
-        {{- if .Values.prefill.podAnnotations }}
-          {{ toYaml .Values.prefill.podAnnotations | nindent 10 }}
-          {{- end }}
+        {{- if $pdSpec.podAnnotations }}
+          {{ toYaml $pdSpec.podAnnotations | nindent 10 }}
+        {{- end }}
         {{- end }}
       spec:
-        {{- /* DEPRECATED; use extraConfig.hostIPC instead */ -}}
-        {{- if hasKey .Values.prefill "hostIPC" }}
-        hostIPC: {{ .Values.prefill.hostIPC }}
+        {{- range $field := list "hostIPC" "hostPID" "enableServiceLinks" "terminationGracePeriodSeconds" }}
+        {{- if hasKey $pdSpec $field }}
+          {{- toYaml (dict $field (index $pdSpec $field)) | nindent 8 }}
         {{- end }}
-        {{- /* DEPRECATED; use extraConfig.hostPID instead */ -}}
-        {{- if hasKey .Values.prefill "hostPID" }}
-        hostPID: {{ .Values.prefill.hostPID }}
         {{- end }}
-        {{- if .Values.prefill.initContainers }}
+        {{- if $pdSpec.initContainers }}
         initContainers:
-        {{- toYaml .Values.prefill.initContainers | nindent 10 }}
+        {{- toYaml $pdSpec.initContainers | nindent 10 }}
         {{- end }}
-        {{- if hasKey .Values.prefill "enableServiceLinks" }}
-        enableServiceLinks: {{ .Values.prefill.enableServiceLinks }}
-        {{- end }}
-        {{- if hasKey .Values.prefill "terminationGracePeriodSeconds" }}
-        terminationGracePeriodSeconds: {{ .Values.prefill.terminationGracePeriodSeconds }}
-        {{- end }}
-        {{- (include "llm-d-modelservice.modelPod" (dict "role" "prefill" "pdSpec" .Values.prefill "Values" .Values "Release" .Release "Chart" .Chart)) | nindent 6 }}
-        {{- with .Values.prefill.containers }}
+        {{- (include "llm-d-modelservice.modelPod" (dict "role" "prefill" "pdSpec" $pdSpec "Values" $.Values "Release" $.Release "Chart" $.Chart "Template" $.Template)) | nindent 6 }}
+        {{- with $pdSpec.containers }}
         containers:
           {{- range . }}
-        {{- (include "llm-d-modelservice.container" (dict "role" "prefill" "container" . "parallelism" $.Values.prefill.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "pdSpec" $.Values.prefill)) | nindent 8 }}
+        {{- (include "llm-d-modelservice.container" (dict "role" "prefill" "container" . "parallelism" $pdSpec.parallelism "Values" $.Values "Release" $.Release "Chart" $.Chart "Template" $.Template "pdSpec" $pdSpec)) | nindent 8 }}
           {{- end }}
         {{- end }}
-        {{- if .Values.prefill.nodeSelector }}
+        {{- if $pdSpec.nodeSelector }}
         nodeSelector:
-          {{- toYaml .Values.prefill.nodeSelector | nindent 10 }}
+          {{- toYaml $pdSpec.nodeSelector | nindent 10 }}
         {{- end }}
-        {{- if .Values.prefill.tolerations }}
+        {{- if $pdSpec.tolerations }}
         tolerations:
-          {{- toYaml .Values.prefill.tolerations | nindent 10 }}
+          {{- toYaml $pdSpec.tolerations | nindent 10 }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -80,6 +80,10 @@ modelArtifacts:
 # When true, a LeaderWorkerSet is used instead of a Deployment
 multinode: false
 
+# When false, only workerTemplate is used (leader and workers share same template)
+# When true, LeaderWorkerSet will use separate leaderTemplate and workerTemplate
+multinodeEnableLeader: false
+
 # Global accelerator configuration
 # Supported types: nvidia, intel-i915, intel-xe, intel-gaudi, amd, google, cpu
 accelerator:
@@ -452,6 +456,19 @@ decode:
       metricRelabelings: []
       # namespaceSelector -- Selector to select which namespaces the Endpoints objects are discovered from
       # namespaceSelector: {}
+  
+  # workerTemplate Required when multinodeEnableLeader is "true"
+  # If not set, it will inherit the leader template; otherwise, it will be overridden 
+  # workerTemplate:
+  #   nodeSelector: {}
+  #   containers:
+  #     - name: "vllm"
+  #       image: "ghcr.io/llm-d/llm-d-inference-sim:latest"
+  #       command: []
+  #       args: []
+  #       env: []
+  #       ports: []
+  #       resources:
 
 # @schema
 # additionalProperties: true
@@ -659,6 +676,19 @@ prefill:
       metricRelabelings: []
       # namespaceSelector -- Selector to select which namespaces the Endpoints objects are discovered from
       # namespaceSelector: {}
+
+  # workerTemplate Required when multinodeEnableLeader is "true"
+  # If not set, it will inherit the leader template; otherwise, it will be overridden 
+  # workerTemplate:
+  #   nodeSelector: {}
+  #   containers:
+  #     - name: "vllm"
+  #       image: "ghcr.io/llm-d/llm-d-inference-sim:latest"
+  #       command: []
+  #       args: []
+  #       env: []
+  #       ports: []
+  #       resources:
 
 # @schema
 # items:

--- a/examples/output-multinode.yaml
+++ b/examples/output-multinode.yaml
@@ -1,0 +1,351 @@
+---
+# Source: llm-d-modelservice/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: llm-d-modelservice
+  labels:
+    helm.sh/chart: llm-d-modelservice-v0.4.8
+    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: llm-d-modelservice/templates/decode-lws.yaml
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: llm-d-modelservice-decode
+  labels:
+    helm.sh/chart: llm-d-modelservice-v0.4.8
+    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/managed-by: Helm
+    llm-d.ai/inference-serving: "true"
+    llm-d.ai/model: deepseek-ai-deepSeek-r1-distill-qwen-1-5B
+    llm-d.ai/role: decode
+spec:
+  replicas: 1
+  leaderWorkerTemplate:
+    size: 2
+    leaderTemplate:
+      metadata:
+        labels:
+          llm-d.ai/inference-serving: "true"
+          llm-d.ai/model: deepseek-ai-deepSeek-r1-distill-qwen-1-5B
+          llm-d.ai/role: decode
+      spec:
+        initContainers:
+          - name: routing-proxy
+            args:
+              - --port=8000
+              - --vllm-port=8200
+              - --connector=nixlv2
+              - --zap-encoder=json
+              - --zap-log-level=debug
+              - --secure-proxy=false
+            image: ghcr.io/llm-d/llm-d-routing-sidecar:latest
+            imagePullPolicy: Always
+            env:
+            ports:
+              - containerPort: 8000
+            resources: {}
+            restartPolicy: Always
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+        
+      
+        serviceAccountName: llm-d-modelservice
+        
+        volumes:
+          - emptyDir: {}
+            name: metrics-volume
+        
+          - name: model-storage
+            emptyDir:
+              sizeLimit: 10Gi
+          
+        
+        containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-cuda:latest
+          
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |
+              ray start --head --port=6379 && vllm serve deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \
+              --port 8200 \
+              --tensor-parallel-size 1 \
+              --pipeline-parallel-size 2 \
+              --distributed-executor-backend ray
+          env:
+          - name: VLLM_LOGGING_LEVEL
+            value: DEBUG
+          - name: DP_SIZE
+            value: "1"
+          - name: TP_SIZE
+            value: "1"
+          - name: DP_SIZE_LOCAL
+            value: "1"
+          
+          - name: HF_HOME
+            value: /model-cache
+          
+          ports:
+          - containerPort: 8200
+            name: vllm
+            protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: 8200
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: "16"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "16"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+          
+          volumeMounts:
+            - mountPath: /.config
+              name: metrics-volume
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - name: model-storage
+              mountPath: /model-cache
+    workerTemplate:
+      metadata:
+        labels:
+          llm-d.ai/inference-serving: "true"
+          llm-d.ai/model: deepseek-ai-deepSeek-r1-distill-qwen-1-5B
+          llm-d.ai/role: decode
+      spec:
+        
+      
+        serviceAccountName: llm-d-modelservice
+        
+        volumes:
+          - emptyDir: {}
+            name: metrics-volume
+        
+          - name: model-storage
+            emptyDir:
+              sizeLimit: 10Gi
+          
+        
+        containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-cuda:latest
+          
+          command:
+            - /bin/bash
+            - -c
+            - ray start --address=$(LWS_LEADER_ADDRESS):6379 --block
+          env:
+          - name: VLLM_LOGGING_LEVEL
+            value: DEBUG
+          - name: DP_SIZE
+            value: "1"
+          - name: TP_SIZE
+            value: "1"
+          - name: DP_SIZE_LOCAL
+            value: "1"
+          
+          - name: HF_HOME
+            value: /model-cache
+          
+          ports:
+          - containerPort: 8200
+            name: vllm
+            protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                pgrep -f "ray" || exit 1
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: "16"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "16"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+          
+          volumeMounts:
+            - mountPath: /.config
+              name: metrics-volume
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - name: model-storage
+              mountPath: /model-cache
+---
+# Source: llm-d-modelservice/templates/prefill-lws.yaml
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: llm-d-modelservice-prefill
+  labels:
+    helm.sh/chart: llm-d-modelservice-v0.4.8
+    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/managed-by: Helm
+    llm-d.ai/inference-serving: "true"
+    llm-d.ai/model: deepseek-ai-deepSeek-r1-distill-qwen-1-5B
+    llm-d.ai/role: prefill
+spec:
+  replicas: 1
+  leaderWorkerTemplate:
+    size: 2
+    leaderTemplate:
+      metadata:
+        labels:
+          llm-d.ai/inference-serving: "true"
+          llm-d.ai/model: deepseek-ai-deepSeek-r1-distill-qwen-1-5B
+          llm-d.ai/role: prefill
+      spec:
+      
+        serviceAccountName: llm-d-modelservice
+        
+        volumes:
+          - emptyDir: {}
+            name: metrics-volume
+        
+          - name: model-storage
+            emptyDir:
+              sizeLimit: 10Gi
+          
+        
+        containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-cuda:latest
+          
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |
+              ray start --head --port=6380 && vllm serve deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \
+              --port 8100 \
+              --tensor-parallel-size 1 \
+              --pipeline-parallel-size 2 \
+              --distributed-executor-backend ray
+          env:
+          - name: DP_SIZE
+            value: "1"
+          - name: TP_SIZE
+            value: "1"
+          - name: DP_SIZE_LOCAL
+            value: "1"
+          
+          - name: HF_HOME
+            value: /model-cache
+          
+          ports:
+          - containerPort: 8100
+            name: vllm
+            protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: 8100
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: "16"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "16"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+          
+          volumeMounts:
+            - mountPath: /.config
+              name: metrics-volume
+            - name: model-storage
+              mountPath: /model-cache
+    workerTemplate:
+      metadata:
+        labels:
+          llm-d.ai/inference-serving: "true"
+          llm-d.ai/model: deepseek-ai-deepSeek-r1-distill-qwen-1-5B
+          llm-d.ai/role: prefill
+      spec:
+      
+        serviceAccountName: llm-d-modelservice
+        
+        volumes:
+          - emptyDir: {}
+            name: metrics-volume
+        
+          - name: model-storage
+            emptyDir:
+              sizeLimit: 10Gi
+          
+        
+        containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-cuda:latest
+          
+          command:
+            - /bin/bash
+            - -c
+            - ray start --address=$(LWS_LEADER_ADDRESS):6380 --block
+          env:
+          - name: DP_SIZE
+            value: "1"
+          - name: TP_SIZE
+            value: "1"
+          - name: DP_SIZE_LOCAL
+            value: "1"
+          
+          - name: HF_HOME
+            value: /model-cache
+          
+          ports:
+          - containerPort: 8100
+            name: vllm
+            protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                pgrep -f "ray" || exit 1
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: "16"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "16"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+          
+          volumeMounts:
+            - mountPath: /.config
+              name: metrics-volume
+            - name: model-storage
+              mountPath: /model-cache

--- a/examples/values-multinode.yaml
+++ b/examples/values-multinode.yaml
@@ -1,0 +1,162 @@
+# This values.yaml file creates the resources for a P/D disaggregation scenario
+# Uses a small model: facebook/opt-125m
+# See also defaults in chart values.yaml
+modelArtifacts:
+  name: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+  labels:
+    llm-d.ai/inference-serving: "true"
+    llm-d.ai/model: deepseek-ai-deepSeek-r1-distill-qwen-1-5B
+  uri: "hf://deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+  size: 10Gi
+
+# Describe routing requirements. In addition to service level routing (OpenAI model name, service port)
+# also describes elements for Gateway API Inference Extension configuration
+routing:
+  proxy:
+    enabled: true
+
+# When true, LeaderWorkerSet is used instead of Deployment
+multinode: true
+# When false, only workerTemplate is used (leader and workers share same template)
+# When true, LeaderWorkerSet will use separate leaderTemplate and workerTemplate
+multinodeEnableLeader: true
+
+# Decode pod configuation
+decode:
+  create: true
+  replicas: 1
+  parallelism:
+    tensor: 1
+    data: 1
+    workers: 2
+  containers:
+    - name: "vllm"
+      image: "ghcr.io/llm-d/llm-d-cuda:latest"
+      modelCommand: custom
+      command:
+        - /bin/bash
+        - '-c'
+      args:
+        - |
+          ray start --head --port=6379 && vllm serve deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \
+          --port 8200 \
+          --tensor-parallel-size 1 \
+          --pipeline-parallel-size 2 \
+          --distributed-executor-backend ray
+      env:
+        - name: VLLM_LOGGING_LEVEL
+          value: DEBUG
+      ports:
+        - name: vllm
+          containerPort: 8200
+          protocol: TCP
+      resources:
+        limits:
+          memory: 16Gi
+          cpu: "16"
+        requests:
+          cpu: "16"
+          memory: 16Gi
+      mountModelVolume: true
+      volumeMounts:
+        - mountPath: /.config
+          name: metrics-volume
+        - mountPath: /dev/shm
+          name: shm
+        - mountPath: /.cache
+          name: torch-compile-cache
+      livenessProbe:
+        failureThreshold: 3
+        httpGet:
+          path: /health
+          port: 8200
+        periodSeconds: 10
+        timeoutSeconds: 5
+  # workerTemplate Required when multinodeEnableLeader is "true"
+  # If not set, it will inherit the leader template; otherwise, it will be overridden 
+  workerTemplate:
+    containers:
+      - name: "vllm"
+        image: "ghcr.io/llm-d/llm-d-cuda:latest"
+        command:
+          - /bin/bash
+          - '-c'
+          - "ray start --address=$(LWS_LEADER_ADDRESS):6379 --block"
+        args: []
+        livenessProbe:
+          exec:
+            command:
+              - /bin/bash
+              - -c
+              - |
+                pgrep -f "ray" || exit 1
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+  
+# Prefill pod configuation
+prefill:
+  create: true
+  replicas: 1
+  parallelism:
+    tensor: 1
+    data: 1
+    workers: 2
+  containers:
+    - name: "vllm"
+      image: "ghcr.io/llm-d/llm-d-cuda:latest"
+      modelCommand: custom
+      command:
+        - /bin/bash
+        - '-c'
+      args:
+        - |
+          ray start --head --port=6380 && vllm serve deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \
+          --port 8100 \
+          --tensor-parallel-size 1 \
+          --pipeline-parallel-size 2 \
+          --distributed-executor-backend ray
+      ports:
+        - name: vllm
+          containerPort: 8100
+          protocol: TCP
+      resources:
+        limits:
+          memory: 16Gi
+          cpu: "16"
+        requests:
+          cpu: "16"
+          memory: 16Gi
+      mountModelVolume: true
+      volumeMounts:
+        - mountPath: /.config
+          name: metrics-volume
+      livenessProbe:
+        failureThreshold: 3
+        httpGet:
+          path: /health
+          port: 8100
+        periodSeconds: 10
+        timeoutSeconds: 5
+  # workerTemplate Required when multinodeEnableLeader is "true"
+  # If not set, it will inherit the leader template; otherwise, it will be overridden
+  workerTemplate:
+    containers:
+      - name: "vllm"
+        image: "ghcr.io/llm-d/llm-d-cuda:latest"
+        command:
+          - /bin/bash
+          - '-c'
+          - "ray start --address=$(LWS_LEADER_ADDRESS):6380 --block"
+        args: []
+        livenessProbe:
+          exec:
+            command:
+              - /bin/bash
+              - -c
+              - |
+                pgrep -f "ray" || exit 1
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+


### PR DESCRIPTION
Add `multinodeEnableLeader` to allow separate customization of leader and worker pod templates in LeaderWorkerSet.

Closes #231

When `multinodeEnableLeader: true` and `workerTemplate` is provided,
LWS renders both templates:
- `leaderTemplate`: generated from the base decode/prefill configuration
- `workerTemplate`: inherits from the base template and applies user overrides

**Example values (decode)**
```yaml
multinode: true
multinodeEnableLeader: true

decode:
  replicas: 1
  parallelism:
    workers: 2
  containers:
    - name: vllm
      image: ghcr.io/llm-d/llm-d-cuda:latest
      modelCommand: custom
      command: ["/bin/bash", "-c"]
      args:
        - |
          ray start --head --port=6379 && vllm serve deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \
          --port 8200 --tensor-parallel-size 1 --pipeline-parallel-size 2 \
          --distributed-executor-backend ray
      livenessProbe:
        httpGet:
          path: /health
          port: 8200
        periodSeconds: 10
        timeoutSeconds: 5

  workerTemplate:
    containers:
      - name: vllm
        # overrides leader command for worker join mode
        command: ["/bin/bash", "-c", "ray start --address=$(LWS_LEADER_ADDRESS):6379 --block"]
        # optional: override args/probes/etc.; unspecified fields are inherited
        args: []
        livenessProbe:
          exec:
            command: ["/bin/bash", "-c", "pgrep -f ray || exit 1"]
          periodSeconds: 10
          timeoutSeconds: 5
```
