### PR TITLE
Add CNCF governance files and CI workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @jgchn @kalantar @yankay

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Describe the bug and expected behavior
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version are you running? (e.g., v0.1.0, commit SHA, or "main")
+      placeholder: v0.1.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Deploy with config...
+        2. Send request to...
+        3. Observe error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Please provide relevant environment details.
+      placeholder: |
+        - Kubernetes version:
+        - Cloud provider:
+        - GPU type:
+        - OS:
+      render: markdown
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussion
+    url: https://github.com/llm-d/llm-d/discussions
+    about: Ask questions and discuss ideas in the llm-d community
+  - name: Slack
+    url: https://cloud-native.slack.com/archives/llm-d
+    about: Chat with the community on Slack

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature Request
+description: Suggest a new feature or improvement.
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Feature Request
+
+        Thank you for suggesting an improvement! Please fill in the details below.
+
+        Before opening a new feature request, please check
+        [existing issues](https://github.com/llm-d/llm-d-modelservice/issues)
+        to see if a similar request already exists.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: |
+        What problem does this feature solve? Describe the use case or pain point.
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: |
+        Describe the solution you'd like. Be as specific as possible about
+        expected behavior and user experience.
+      placeholder: "Ideally, it would..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or workarounds you've considered.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Willingness to Contribute
+      description: Would you be willing to help implement this feature?
+      options:
+        - "Yes, I can submit a PR"
+        - "Yes, with guidance"
+        - "No, but I can help test"
+        - "No"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, links, or references.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,8 @@
 
 ## Checklist
 
-- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
-- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
+- [ ] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
+- [ ] Code follows project [contributing guidelines](../CONTRIBUTING.md)
 - [ ] Pre-commit hooks pass (`make pre-commit-run`)
 - [ ] Linters pass (`make lint`)
 - [ ] Generated examples are in sync (`make verify`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## What does this PR do?
+
+<!-- Describe the changes and their purpose -->
+
+## Why is this change needed?
+
+<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->
+
+## How was this tested?
+
+<!-- Describe how you verified the changes work correctly -->
+- [ ] Manual testing performed
+- [ ] `helm template` dry run verified
+
+## Checklist
+
+- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
+- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
+- [ ] Pre-commit hooks pass (`make pre-commit-run`)
+- [ ] Linters pass (`make lint`)
+- [ ] Generated examples are in sync (`make verify`)
+- [ ] Chart version bumped (`make bump-chart-version-{patch|minor|major}`)
+- [ ] Documentation updated (if applicable)
+
+## Related Issues
+
+<!-- Link to related issues: Fixes #123, Related to #456 -->

--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -1,0 +1,9 @@
+name: Check Signed Commits
+on: pull_request_target
+
+jobs:
+  signed-commits:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -1,0 +1,8 @@
+name: Non-Main Gatekeeper
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  gatekeeper:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@main

--- a/.prowlabels.yaml
+++ b/.prowlabels.yaml
@@ -1,0 +1,11 @@
+# Labels for labeling issues and pull requests using GitHub prow action.
+kind:
+  - 'bug'
+  - 'security'
+  - 'feature'
+  - 'docs'
+
+priority:
+  - 'p0'
+  - 'p1'
+  - 'p2'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+## Code of Conduct and Covenant
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.Attribution
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+
+For answers to common questions about this code of conduct, see <https://www.contributor-covenant.org/faq>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -28,7 +28,10 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.Attribution
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Attribution
+
 This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
 
 For answers to common questions about this code of conduct, see <https://www.contributor-covenant.org/faq>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,31 @@
 # Contributing to `llm-d-modelservice`
 
-Thank you for your interest in contributing to llm-d-modelservice. This document provides guidelines and instructions for contributing to this project.
+Thank you for your interest in contributing to llm-d-modelservice! Community involvement is highly valued and crucial for the project's growth and success. This project accepts contributions via GitHub pull requests. This document outlines the process to help get your contribution accepted.
 
-To ensure a clear direction and cohesive vision for the project, the project leads have the final decision on all contributions. However, these guidelines outline how you can contribute effectively to llm-d-modelservice.
+To ensure a clear direction and cohesive vision for the project, the project leads have the final decision on all contributions. However, these guidelines outline how you can contribute effectively.
 
 ## How You Can Contribute
 
-There are several ways you can contribute to llm-d-modelservice:
+There are several ways you can contribute:
 
 * **Reporting Issues:** Help us identify and fix bugs by reporting them clearly and concisely.
 * **Suggesting Features:** Share your ideas for new features or improvements.
 * **Improving Documentation:** Help make the project more accessible by enhancing the documentation.
-* **Submitting Code Contributions (with consideration):** While the project leads maintain final say, code contributions that align with the project's vision are always welcome.
+* **Submitting Code Contributions:** Code contributions that align with the project's vision are always welcome.
 
 ## Code of Conduct
 
-This project adheres to the llm-d [Code of Conduct](https://github.com/llm-d/llm-d/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+This project adheres to the [Code of Conduct and Covenant](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## Community and Communication
+
+* **Developer Slack:** [Join our developer Slack workspace](https://llm-d.ai/slack) to connect with the core maintainers and other contributors, ask questions, and participate in discussions.
+* **Weekly Meetings:** Project updates, ongoing work discussions, and Q&A will be covered in our weekly project meetings. Please join by [adding the shared calendar](https://red.ht/llm-d-public-calendar). You can also [join our Google Group](https://groups.google.com/g/llm-d-contributors) for access to shared content.
+* **Code:** Hosted in the [llm-d](https://github.com/llm-d) GitHub organization
+* **Issues:** Project-scoped bugs or issues should be reported in this repo or in [llm-d/llm-d](https://github.com/llm-d/llm-d)
+* **Mailing List:** [llm-d-contributors@googlegroups.com](mailto:llm-d-contributors@googlegroups.com)
 
 ## Local Development Setup
-
-We welcome contributions to the llm-d-modelservice chart! If you have a bug fix, feature request, or improvement, please submit a pull request (PR) to the repository.
 
 Before submitting a pull request, please make sure you have the following tools installed:
 
@@ -75,14 +81,62 @@ You can also run pre-commit manually on all files:
 make pre-commit-run
 ```
 
+## Contributing Process
+
+We follow a **lazy consensus** approach: changes proposed by people with responsibility for a problem, without disagreement from others, within a bounded time window of review by their peers, should be accepted.
+
+### Types of Contributions
+
+#### 1. Features with Public APIs or New Components
+
+All features involving public APIs, behavior between core components, or new core subsystems must be accompanied by an **approved project proposal**.
+
+**Process:**
+
+1. Create a pull request adding a proposal document under `./docs/proposals/` with a descriptive name
+2. Include these sections: Summary, Motivation (Goals/Non-Goals), Proposal, Design Details, Alternatives
+3. Get review from impacted component maintainers
+4. Get approval from project maintainers
+
+#### 2. Fixes, Issues, and Bugs
+
+For changes that fix broken code or add small changes within a component:
+
+* All bugs and commits must have a clear description of the bug, how to reproduce, and how the change is made
+* Any other changes can be proposed in a pull request — a maintainer must approve the change
+* For moderate size changes, create an RFC issue in GitHub, then engage in Slack
+
+## Code Review Requirements
+
+* **All code changes** must be submitted as pull requests (no direct pushes)
+* **All changes** must be reviewed and approved by a maintainer other than the author
+* **All repositories** must gate merges on compilation and passing tests
+* **All experimental features** must be off by default and require explicit opt-in
+
+## Commit and Pull Request Style
+
+* **Pull requests** should describe the problem succinctly
+* **Rebase and squash** before merging
+* **Use minimal commits** and break large changes into distinct commits
+* **Commit messages** should have:
+  * Short, descriptive titles
+  * Description of why the change was needed
+  * Enough detail for someone reviewing git history to understand the scope
+* **DCO Sign-off**: All commits must include a valid DCO sign-off line (`Signed-off-by: Name <email@domain.com>`)
+  * Add automatically with `git commit -s`
+  * See [PR_SIGNOFF.md](PR_SIGNOFF.md) for configuration details
+  * Required for all contributions per [Developer Certificate of Origin](https://developercertificate.org/)
+
 ## Submitting a Pull Request
 
 For every Pull Request submitted, ensure the following steps have been done:
 
 1. [Sign your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 2. [Sign-off your commits](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff)
-3. Ensure that the `make lint`, `make verify` command runs successfully to validate your changes
-4. Update the version number in the [`charts/llm-d-modelservice/Chart.yaml`](charts/llm-d-modelservice/Chart.yaml) file using
+3. Run pre-commit hooks to ensure code quality and schema validation: `make pre-commit-run`
+4. Ensure that `make lint` passes to validate your changes
+5. Ensure that `make verify` passes to confirm generated examples are in sync
+6. Update the version number in the [`charts/llm-d-modelservice/Chart.yaml`](charts/llm-d-modelservice/Chart.yaml) file using
    [semantic versioning](https://semver.org/). Follow the `X.Y.Z` format so the nature of the changes is reflected in the
    chart.
    - `X` (major) is incremented for breaking changes,
@@ -90,9 +144,25 @@ For every Pull Request submitted, ensure the following steps have been done:
    - `Z` (patch) is incremented for bug fixes, minor improvements, or non-breaking changes.
 
    If you modify the chart, please bump the chart version. You can run `make bump-chart-version-patch` to automatically increment the patch version. After updating the chart, run `make lint` to validate your changes.
-5. Run pre-commit hooks to ensure code quality and schema validation: `make pre-commit-run`
-6. Lint tests have been run for the Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `make lint` command.
-<!-- TODO after the helm-docs supported: 7. Make sure that [helm-docs](https://github.com/norwoodj/helm-docs) has been run to generate/update the `README.md` documentation. To preview the content, use `helm-docs --dry-run`. -->
+7. Lint tests have been run for the Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `make lint` command.
+<!-- TODO after the helm-docs supported: 8. Make sure that [helm-docs](https://github.com/norwoodj/helm-docs) has been run to generate/update the `README.md` documentation. To preview the content, use `helm-docs --dry-run`. -->
+
+## Code Organization and Ownership
+
+* **Components** are the primary unit of code organization
+* **Maintainers** own components and approve changes
+* **Contributors** can become maintainers through sufficient evidence of contribution
+* Code ownership is reflected in [OWNERS files](https://go.k8s.io/owners) consistent with Kubernetes project conventions
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for our vulnerability disclosure process.
+
+## API Changes and Deprecation
+
+* **No breaking changes**: Once an API/protocol is in GA release, it cannot be removed or behavior changed
+* **Versioning**: All protocols and APIs should be versionable with clear compatibility requirements
+* **Documentation**: All APIs must have documented specs describing expected behavior
 
 ## FAQ and Troubleshooting
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/PR_SIGNOFF.md
+++ b/PR_SIGNOFF.md
@@ -1,0 +1,203 @@
+# Git Commit Signoff and Signing
+
+**NOTE**: "sign-off" is different from "signing" a commit.  The former
+indicates your assent to the repository's terms for contributors, the
+latter adds a cryptographic signature that is rarely displayed.  See
+[the git
+book](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work)
+about signing. For commit signoff, do a web search on `git
+signoff`. GitHub has a concept of [a commit being
+"verified"](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+that extends the Git concept of signing.
+
+In order to get a pull request approved, you must first complete a DCO
+sign-off for each commit that the request is asking to add to the
+repository. This process is defined by the CNCF, and there are two
+cases: individual contributors and contributors that work for a
+corporate CNCF member. Both mean consent with the terms stated in [the
+`DCO` file at the root of this Git
+repository](https://github.com/llm-d/llm-d/blob/main/DCO). In
+the case of an individual, DCO sign-off is accomplished by doing a Git
+"sign-off" on the commit.
+
+We prefer that commits contributed to this repository be signed and
+GitHub verified, but this is not strictly necessary or enforced.
+
+## Commit Sign-off
+
+Your submitted PR must pass the automated checks in order to be merged. One of these checks that each commit that you propose to contribute is signed-off. If you use the `git` shell command, this involves passing the `-s` flag on the command line. For example, the following command will create a signed-off commit but _not_ sign it.
+
+```shell
+git commit -s
+```
+
+Alternatively, the following command will create a commit that is both signed-off and signed.
+
+```shell
+git commit -s -S
+```
+
+For other tools, consult their documentation.
+
+## Signing Commits
+
+Before signing any commits, you must have a GPG or SSH key. Basic setup instructions can be found below (For more detailed instructions, refer to the Github [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) and [SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) setup pages.)
+
+To sign a particular commit, you must either include `-S` on the `git commit` command line (see the command exhibited above for an example) or have configured automatic signing (see ["Everyone Must Sign" in the Git Book](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work#_everyone_must_sign) for a hint about that).
+
+Before starting, make sure that your user email is verified on Github. To check for this:
+
+1. Login to Github and navigate to your Github **Settings** page
+2. In the sidebar, open the **Emails** tab
+3. Emails associated with Github should be listed at the top of the page under the "Emails" label
+4. An unverified email would have an "Unverified" label under it in orange text
+5. To verify, click **Resend verification email** and follow its prompts
+6. Navigate back to your **Emails** page, if the "Unverified" label is no longer there, then you're good to go!
+
+<br />
+
+For Windows users, **Git Bash** is also highly recommended.
+
+<br />
+
+## Setting up the GPG Key
+
+1. Install GnuPG (the GPG command line tool).
+    - Binary releases for your specific OS can be found
+      [on the GnuPG download page](https://www.gnupg.org/download/) after scrolling down to the Binary Releases
+      section (i.e. Gpg4win on Windows, Mac GPG for MacOS, etc).
+    - After downloading the installer, follow the prompts to set up GnuPG.
+
+2. Open Git Bash (or your CLI of choice) and use the following command to generate your GPG key pair:
+
+   ```shell
+   gpg --full-generate-key
+   ```
+
+3. If prompted to specify the size, type, and duration of the key that you want, press `Enter` to select the default option.
+4. Once prompted, enter your user info and a passphrase:
+    - Make sure to list your email as the same one that's verified by Github
+5. Use the following command to list the long form of your generated GPG keys:
+
+   ```shell
+   gpg --list-secret-keys --keyid-format=long
+   ```
+
+    - Your GPG key ID should be the characters on the output line starting with `sec`, beginning directly after the `/` and ending before the listed date.
+    - For example, in the output below (from the Github [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) setup page), the GPG key ID would be `3AA5C34371567BD2`
+
+        ```shell
+        $ gpg --list-secret-keys --keyid-format=long
+         /Users/hubot/.gnupg/secring.gpg
+         ------------------------------------
+         sec   4096R/3AA5C34371567BD2 2016-03-10 [expires: 2017-03-10]
+         uid                          Hubot <hubot@example.com>
+         ssb   4096R/4BB6D45482678BE3 2016-03-10
+        ```
+
+6. Copy your GPG key ID and run the command below, replacing `[your_GPG_key_ID]` with the key ID you just copied:
+
+    ```shell
+    gpg --armor --export [your_GPG_key_ID]
+    ```
+
+7. This should generate an output with your GPG key. Copy the characters starting from `-----BEGIN PGP PUBLIC KEY BLOCK-----` and ending at `--END PGP PUBLIC KEY BLOCK-----` (inclusive) to your clipboard.
+8. After copying or saving your GPG key, navigate to **Settings** in your Github
+9. Navigate to the **SSH and GPG keys** page under the Access section in the sidebar
+10. Under GPG keys, select **New GPG key**
+    - Enter a suitable name for your key under "Title" and paste your GPG key that you copied/saved in **Step 7** under "Key".
+    - Once done, click **Add GPG key**
+11. Your new GPG key should now be displayed under GPG keys.
+
+<br />
+
+## Setting up the SSH Key
+
+1. Open Git Bash (or your CLI of choice) and use the following command to generate your new SSH key (make sure to replace `your_email` with your Github-verified email address):
+
+    ```shell
+    ssh-keygen -t ed25519 -C "your_email"
+    ```
+
+2. Press `Enter` to select the default option if prompted to set a save-file or passphrase for the key (you may choose to enter a passphrase if desired; this will prompt you to enter the passphrase every time you perform a DCO sign-off).
+   - The following output should generate a `randomart` image
+3. Use the following command to copy the **public** part of the new SSH key to your clipboard:
+
+    ```shell
+    clip < ~/.ssh/id_ed25519.pub
+    ```
+
+    Note: If you are in a WSL shell, use instead
+
+   ```shell
+   clip.exe < ~/.ssh/id_ed25519.pub
+   ```
+
+4. After copying or saving your SSH key, navigate to **Settings** in your Github.
+5. Navigate to the **SSH and GPG keys** page under the Access section in the sidebar.
+6. Under SSH keys, select **New SSH key**.
+    - Enter a suitable name for your key under "Title" (it'll pick up the email address if left empty)
+    - Open the dropdown menu under "Key type" and select **Signing Key**
+    - Paste your SSH public key that you copied/saved in **Step 3** under "Key"
+7. Your new SSH key should now be displayed under SSH keys, in the **Signing Key** section.
+8. **Optional**: If you want to use the same SSH or GPG key for authentication as well, repeat steps above, selecting **Authentication** as the "Key type".
+9. **Optional**: To test if your SSH key is connecting properly or not, run the following command in your CLI (more specific instructions can be found in the [Github documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection)):
+
+    ```shell
+    ssh -T git@github.com
+    ```
+
+    - If given a warning saying something like `The authenticity of the host '[host IP]' can't be established` along
+      with a key fingerprint and a prompt to continue, verify if the provided key fingerprint matches any of those
+      listed [in GitHub's SSH key fingerprints documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)
+    - Once you've verified the match, type `yes`
+    - If the resulting message says something along the lines of `Hi [User]! You've successfully authenticated, but GitHub does not provide shell access.`, then it means your SSH key is up and ready.
+    - If you get an error saying something like `Error: Permission denied (publickey)` repeat the procedure in step 6 _with the same key_ only select **Authentication Key**. Then try the test command again.
+
+<br />
+
+## Creating Pull Requests Using the GitHub Website
+
+This is not recommended for individual contributors, because the commits that it produces are not "signed-off" (as defined by Git) and thus do not carry assent to the DCO; see [Repairing commits](#repairing-commits) below for a way to recover if you have inadvertently made such a PR. For corporate contributors the DCO assent is indicated differently.
+
+Whether it's editing files from llm-d.ai or directly from the llm-d Github, there are a couple steps to follow that streamlines the workflow of your PR:
+
+1. Changes made to any file are automatically committed to a new branch in your fork.
+    - After clicking **Commit changes...**, write your commit message summary line and any extended description that you want. Then click **Propose changes**, review your changes, and then create the PR.
+    - When making the PR, make sure to specify the type of PR at the beginning of the PR's title (i.e. :bug: if it addresses a bug-type issue)
+
+1. If the PR addresses a specific issue that has already been opened in GitHub, make sure to include the open issue number in **Related Issue(s)** (i.e. `Fixes #NNNN`); this will cause GitHub to automatically close the Issue once the PR is merged. If you have finished addressing an open issue without getting it automatically closed then explicitly close it.
+
+## Repairing commits
+
+If you have already created a PR that proposes to merge a branch that
+adds commits that are not signed-off then you can repair this (and
+lack of signing, if you choose) by adding the signoff to each using
+`git commit -s --amend` on each of them. If you also want those
+commits signed then you would use `git commit -s -S --amend` or
+configure automatic signing. Following is an outline of how to do it
+for a branch that adds **exactly one** commit. If your branch adds
+more than one commit then you can extrapolate using `git cherry-pick -s -S`
+(or `git rebase -i HEAD~NN` and setting commits to `edit`) to build up a
+revised series of commits one-by-one.
+
+The following instructions provide a basic walk-through if you have already created your own fork of the repository but yet not made a clone on your workstation.
+
+1. Navigate to the **Code** page of the llm-d github.
+
+2. Click the **Fork** dropdown in the top right corner of the page.
+    - Under "Existing Forks" click your fork (should look something like "your_username/llm-d")
+3. Once in your fork, click the **Code** dropdown.
+    - Under the "Local" tab at the top of the dropdown, select the SSH tab
+    - Copy the SSH repo URL to your clipboard
+4. Open Git Bash (or your CLI of choice), create or change to a different directory if desired.
+5. Clone the repository using `git clone` followed by pasting the URL you just copied.
+6. Change your directory to the llm-d repo using `cd llm-d`.
+7. `git checkout` to the branch in your fork where the changes were committed.
+    - The branch name should be written at the top of your submitted PR page and looks something like "patch-_X_" (where "X" should be the number of PRs made on your fork to date)
+8. Once in your branch, type `git commit -s --amend` to sign off your PR.
+    - The commit will also be signed if either you have set up automatic signing or both include the `-S` flag on that command and have set up your SSH or GPG key.
+    - You may extend that command with `-m` followed by a quoted commit message if you desire. Otherwise `git` will pop up an editor for you to use in making any desired adjustment to the commit message. After making any desired changes, save and exit the editor. FYI: in `vi` (which GitBash uses), when it is in Command mode (which is the normal mode, and contrasts with Insert mode) the keystrokes `:wq!` will attempt to save and then will exit no matter what.
+9. Type `git push -f origin [branch_name]`, replacing `[branch_name]` with the actual name of your branch.
+10. Navigate back to your PR github page.
+    - A green `dco-signoff: yes` label indicates that your PR is successfully signed

--- a/PR_SIGNOFF.md
+++ b/PR_SIGNOFF.md
@@ -14,9 +14,9 @@ In order to get a pull request approved, you must first complete a DCO
 sign-off for each commit that the request is asking to add to the
 repository. This process is defined by the CNCF, and there are two
 cases: individual contributors and contributors that work for a
-corporate CNCF member. Both mean consent with the terms stated in [the
-`DCO` file at the root of this Git
-repository](https://github.com/llm-d/llm-d/blob/main/DCO). In
+corporate CNCF member. Both mean consent with the terms stated in the
+llm-d project's [Developer Certificate of Origin
+(`DCO`)](https://github.com/llm-d/llm-d/blob/main/DCO). In
 the case of an individual, DCO sign-off is accomplished by doing a Git
 "sign-off" on the commit.
 
@@ -25,7 +25,7 @@ GitHub verified, but this is not strictly necessary or enforced.
 
 ## Commit Sign-off
 
-Your submitted PR must pass the automated checks in order to be merged. One of these checks that each commit that you propose to contribute is signed-off. If you use the `git` shell command, this involves passing the `-s` flag on the command line. For example, the following command will create a signed-off commit but _not_ sign it.
+Your submitted PR must pass the automated checks in order to be merged. One of these checks verifies that each commit that you propose to contribute is signed-off. If you use the `git` shell command, this involves passing the `-s` flag on the command line. For example, the following command will create a signed-off commit but _not_ sign it.
 
 ```shell
 git commit -s
@@ -41,15 +41,15 @@ For other tools, consult their documentation.
 
 ## Signing Commits
 
-Before signing any commits, you must have a GPG or SSH key. Basic setup instructions can be found below (For more detailed instructions, refer to the Github [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) and [SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) setup pages.)
+Before signing any commits, you must have a GPG or SSH key. Basic setup instructions can be found below (For more detailed instructions, refer to the GitHub [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) and [SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) setup pages.)
 
 To sign a particular commit, you must either include `-S` on the `git commit` command line (see the command exhibited above for an example) or have configured automatic signing (see ["Everyone Must Sign" in the Git Book](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work#_everyone_must_sign) for a hint about that).
 
-Before starting, make sure that your user email is verified on Github. To check for this:
+Before starting, make sure that your user email is verified on GitHub. To check for this:
 
-1. Login to Github and navigate to your Github **Settings** page
+1. Login to GitHub and navigate to your GitHub **Settings** page
 2. In the sidebar, open the **Emails** tab
-3. Emails associated with Github should be listed at the top of the page under the "Emails" label
+3. Emails associated with GitHub should be listed at the top of the page under the "Emails" label
 4. An unverified email would have an "Unverified" label under it in orange text
 5. To verify, click **Resend verification email** and follow its prompts
 6. Navigate back to your **Emails** page, if the "Unverified" label is no longer there, then you're good to go!
@@ -76,7 +76,7 @@ For Windows users, **Git Bash** is also highly recommended.
 
 3. If prompted to specify the size, type, and duration of the key that you want, press `Enter` to select the default option.
 4. Once prompted, enter your user info and a passphrase:
-    - Make sure to list your email as the same one that's verified by Github
+    - Make sure to list your email as the same one that's verified by GitHub
 5. Use the following command to list the long form of your generated GPG keys:
 
    ```shell
@@ -84,7 +84,7 @@ For Windows users, **Git Bash** is also highly recommended.
    ```
 
     - Your GPG key ID should be the characters on the output line starting with `sec`, beginning directly after the `/` and ending before the listed date.
-    - For example, in the output below (from the Github [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) setup page), the GPG key ID would be `3AA5C34371567BD2`
+    - For example, in the output below (from the GitHub [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) setup page), the GPG key ID would be `3AA5C34371567BD2`
 
         ```shell
         $ gpg --list-secret-keys --keyid-format=long
@@ -102,7 +102,7 @@ For Windows users, **Git Bash** is also highly recommended.
     ```
 
 7. This should generate an output with your GPG key. Copy the characters starting from `-----BEGIN PGP PUBLIC KEY BLOCK-----` and ending at `--END PGP PUBLIC KEY BLOCK-----` (inclusive) to your clipboard.
-8. After copying or saving your GPG key, navigate to **Settings** in your Github
+8. After copying or saving your GPG key, navigate to **Settings** in your GitHub
 9. Navigate to the **SSH and GPG keys** page under the Access section in the sidebar
 10. Under GPG keys, select **New GPG key**
     - Enter a suitable name for your key under "Title" and paste your GPG key that you copied/saved in **Step 7** under "Key".
@@ -113,7 +113,7 @@ For Windows users, **Git Bash** is also highly recommended.
 
 ## Setting up the SSH Key
 
-1. Open Git Bash (or your CLI of choice) and use the following command to generate your new SSH key (make sure to replace `your_email` with your Github-verified email address):
+1. Open Git Bash (or your CLI of choice) and use the following command to generate your new SSH key (make sure to replace `your_email` with your GitHub-verified email address):
 
     ```shell
     ssh-keygen -t ed25519 -C "your_email"
@@ -133,7 +133,7 @@ For Windows users, **Git Bash** is also highly recommended.
    clip.exe < ~/.ssh/id_ed25519.pub
    ```
 
-4. After copying or saving your SSH key, navigate to **Settings** in your Github.
+4. After copying or saving your SSH key, navigate to **Settings** in your GitHub.
 5. Navigate to the **SSH and GPG keys** page under the Access section in the sidebar.
 6. Under SSH keys, select **New SSH key**.
     - Enter a suitable name for your key under "Title" (it'll pick up the email address if left empty)
@@ -141,7 +141,7 @@ For Windows users, **Git Bash** is also highly recommended.
     - Paste your SSH public key that you copied/saved in **Step 3** under "Key"
 7. Your new SSH key should now be displayed under SSH keys, in the **Signing Key** section.
 8. **Optional**: If you want to use the same SSH or GPG key for authentication as well, repeat steps above, selecting **Authentication** as the "Key type".
-9. **Optional**: To test if your SSH key is connecting properly or not, run the following command in your CLI (more specific instructions can be found in the [Github documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection)):
+9. **Optional**: To test if your SSH key is connecting properly or not, run the following command in your CLI (more specific instructions can be found in the [GitHub documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection)):
 
     ```shell
     ssh -T git@github.com
@@ -160,7 +160,7 @@ For Windows users, **Git Bash** is also highly recommended.
 
 This is not recommended for individual contributors, because the commits that it produces are not "signed-off" (as defined by Git) and thus do not carry assent to the DCO; see [Repairing commits](#repairing-commits) below for a way to recover if you have inadvertently made such a PR. For corporate contributors the DCO assent is indicated differently.
 
-Whether it's editing files from llm-d.ai or directly from the llm-d Github, there are a couple steps to follow that streamlines the workflow of your PR:
+Whether it's editing files from llm-d.ai or directly from the llm-d GitHub, there are a couple steps to follow that streamlines the workflow of your PR:
 
 1. Changes made to any file are automatically committed to a new branch in your fork.
     - After clicking **Commit changes...**, write your commit message summary line and any extended description that you want. Then click **Propose changes**, review your changes, and then create the PR.
@@ -183,7 +183,7 @@ revised series of commits one-by-one.
 
 The following instructions provide a basic walk-through if you have already created your own fork of the repository but yet not made a clone on your workstation.
 
-1. Navigate to the **Code** page of the llm-d github.
+1. Navigate to the **Code** page of the llm-d GitHub.
 
 2. Click the **Fork** dropdown in the top right corner of the page.
     - Under "Existing Forks" click your fork (should look something like "your_username/llm-d")
@@ -199,5 +199,5 @@ The following instructions provide a basic walk-through if you have already crea
     - The commit will also be signed if either you have set up automatic signing or both include the `-S` flag on that command and have set up your SSH or GPG key.
     - You may extend that command with `-m` followed by a quoted commit message if you desire. Otherwise `git` will pop up an editor for you to use in making any desired adjustment to the commit message. After making any desired changes, save and exit the editor. FYI: in `vi` (which GitBash uses), when it is in Command mode (which is the normal mode, and contrasts with Insert mode) the keystrokes `:wq!` will attempt to save and then will exit no matter what.
 9. Type `git push -f origin [branch_name]`, replacing `[branch_name]` with the actual name of your branch.
-10. Navigate back to your PR github page.
+10. Navigate back to your PR GitHub page.
     - A green `dco-signoff: yes` label indicates that your PR is successfully signed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+## Security Announcements
+
+Join the [llm-d-security-announce](https://groups.google.com/u/1/g/llm-d-security-announce) group for emails about security and major API announcements.
+
+## Report a Vulnerability
+
+We're extremely grateful for security researchers and users that report vulnerabilities to the llm-d Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
+
+You can email the private [llm-d-security-reporting@googlegroups.com](mailto:llm-d-security-reporting@googlegroups.com) list with the security details and the details expected for [all llm-d bug reports](.github/ISSUE_TEMPLATE/bug.yml).
+
+### When Should I Report a Vulnerability?
+
+- You think you discovered a potential security vulnerability in llm-d
+- You are unsure how a vulnerability affects llm-d
+- You think you discovered a vulnerability in another project that llm-d depends on
+  - For projects with their own vulnerability reporting and disclosure process, please report it directly there
+
+### When Should I NOT Report a Vulnerability?
+
+- You need help tuning llm-d components for security
+- You need help applying security related updates
+- Your issue is not security related
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the maintainers of llm-d within 3 working days.
+
+Any vulnerability information shared with Security Response Committee stays within llm-d project and will not be disseminated to other projects unless it is necessary to get the issue fixed.
+
+As the security issue moves from triage, to identified fix, to release planning we will keep the reporter updated.
+
+## Public Disclosure Timing
+
+A public disclosure date is negotiated by the llm-d Security Response Committee and the bug submitter.
+We prefer to fully disclose the bug as soon as possible once a user mitigation is available.
+It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination.
+The timeframe for disclosure is from immediate (especially if it's already publicly known) to a few weeks.
+For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days.
+The llm-d maintainers hold the final say when setting a disclosure date.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Join the [llm-d-security-announce](https://groups.google.com/u/1/g/llm-d-securit
 
 We're extremely grateful for security researchers and users that report vulnerabilities to the llm-d Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
 
-You can email the private [llm-d-security-reporting@googlegroups.com](mailto:llm-d-security-reporting@googlegroups.com) list with the security details and the details expected for [all llm-d bug reports](.github/ISSUE_TEMPLATE/bug.yml).
+You can email the private [llm-d-security-reporting@googlegroups.com](mailto:llm-d-security-reporting@googlegroups.com) list with the security details and the details expected for [all llm-d bug reports](.github/ISSUE_TEMPLATE/bug_report.yml).
 
 ### When Should I Report a Vulnerability?
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,14 @@
+# Typos configuration
+# https://github.com/crate-ci/typos
+
+[default.extend-words]
+# Azure Kubernetes Service abbreviation
+AKS = "AKS"
+aks = "aks"
+# Indian Standard Time / Istio abbreviation
+IST = "IST"
+# Abbreviation (e.g., 2nd -> ND)
+ND = "ND"
+
+# Add repo-specific false positives here:
+# word = "word"


### PR DESCRIPTION
## Summary
- Add all missing CNCF governance and CI compliance files per the [llm-d-go-template](https://github.com/llm-d/llm-d-go-template)
- Merge CONTRIBUTING.md with org-wide sections (community links, lazy consensus, proposal process, code review, commit style, API deprecation) while preserving existing local dev setup content
- Customize CODEOWNERS, PR template (Helm-specific checklist with correct `make pre-commit-run` → `make lint` → `make verify` ordering), and feature request template

### Files added (13 new):
| File | Notes |
|------|-------|
| `LICENSE` | Apache 2.0 (direct copy) |
| `CODE_OF_CONDUCT.md` | Contributor Covenant v1.4 (direct copy) |
| `SECURITY.md` | Org-wide vulnerability policy (direct copy) |
| `PR_SIGNOFF.md` | DCO sign-off/signing guide (direct copy) |
| `_typos.toml` | Typos checker config (direct copy) |
| `.prowlabels.yaml` | Prow label definitions (direct copy) |
| `.github/CODEOWNERS` | Populated with actual team members |
| `.github/PULL_REQUEST_TEMPLATE.md` | Helm chart-specific checklist |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Structured bug form (direct copy) |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | `{{PROJECT_NAME}}` → `llm-d-modelservice` |
| `.github/ISSUE_TEMPLATE/config.yml` | Disables blank issues (direct copy) |
| `.github/workflows/ci-signed-commits.yaml` | Reusable workflow (direct copy) |
| `.github/workflows/non-main-gatekeeper.yml` | Reusable workflow (direct copy) |

### Files modified (1):
| File | Notes |
|------|-------|
| `CONTRIBUTING.md` | Merged template org-wide sections with existing local dev content |

### Not modified:
- `OWNERS` — already populated with correct team members

## Test plan
- [x] All pre-commit hooks pass
- [ ] Verify CI workflows trigger correctly on a test PR
- [ ] Verify issue templates render correctly in GitHub UI

Fixes #238