### PR TITLE
feat: Added bitnami style image registry override

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "v0.4.11"
+version: "v0.4.12"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -91,6 +91,38 @@ affinity:
             {{- end }}
 {{- end }}
 {{- end }}
+
+{{/* Rewrite an image reference to use a global registry override */}}
+{{- define "llm-d-modelservice.resolveImage" -}}
+{{- $image := required "image is required" .image -}}
+{{- $registryOverride := trimSuffix "/" (default "" .Values.global.imageRegistry) -}}
+{{- if not $registryOverride -}}
+{{- $image -}}
+{{- else -}}
+{{- $parts := splitList "/" $image -}}
+{{- $nameParts := $parts -}}
+{{- $first := index $parts 0 -}}
+{{- if and (gt (len $parts) 1) (or (contains "." $first) (contains ":" $first) (eq $first "localhost")) -}}
+{{- $nameParts = slice $parts 1 -}}
+{{- end -}}
+{{- printf "%s/%s" $registryOverride (join "/" $nameParts) -}}
+{{- end -}}
+{{- end }}
+
+{{/* Render a list of container-like objects while applying image resolution */}}
+{{- define "llm-d-modelservice.renderContainerList" -}}
+{{- $renderedContainers := list -}}
+{{- range $container := (.containers | default list) -}}
+{{- $rendered := deepCopy $container -}}
+{{- if hasKey $rendered "image" -}}
+{{- $_ := set $rendered "image" (include "llm-d-modelservice.resolveImage" (dict "image" (index $rendered "image") "Values" $.Values) | trim) -}}
+{{- end -}}
+{{- $renderedContainers = append $renderedContainers $rendered -}}
+{{- end -}}
+{{- toYaml $renderedContainers -}}
+{{- end }}
+
+
 {{/* Create the init container for the routing proxy/sidecar for decode pods */}}
 {{- define "llm-d-modelservice.routingProxy" -}}
 {{- if or (not (hasKey .proxy "enabled")) (ne .proxy.enabled false) -}}
@@ -123,7 +155,7 @@ affinity:
     {{- if hasKey .proxy "certPath" }}
     - --cert-path={{ .proxy.certPath }}
     {{- end }}
-  image: {{ required "routing.proxy.image must be specified" .proxy.image }}
+  image: {{ include "llm-d-modelservice.resolveImage" (dict "image" (required "routing.proxy.image must be specified" .proxy.image) "Values" .Values) | trim }}
   imagePullPolicy: {{ default "Always" .proxy.imagePullPolicy }}
   env:
 {{- if and .Values.tracing .Values.tracing.enabled }}
@@ -465,7 +497,7 @@ context is a dict with helm root context plus:
 */}}
 {{- define "llm-d-modelservice.container" -}}
 - name: {{ default "vllm" .container.name }}
-  image: {{ required "image of container is required" .container.image }}
+  image: {{ include "llm-d-modelservice.resolveImage" (dict "image" (required "image of container is required" .container.image) "Values" .Values) | trim }}
   {{- with .container.extraConfig }}
     {{ include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 2 }}
   {{- end }}

--- a/charts/llm-d-modelservice/templates/decode-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/decode-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       initContainers:
       {{- (include "llm-d-modelservice.routingProxy" (dict "proxy" .Values.routing.proxy "servicePort" .Values.routing.servicePort "Values" .Values)) | nindent 8 }}
       {{- if .Values.decode.initContainers }}
-      {{- toYaml .Values.decode.initContainers | nindent 8 }}
+      {{- include "llm-d-modelservice.renderContainerList" (dict "containers" .Values.decode.initContainers "Values" .Values) | nindent 8 }}
       {{- end }}
       {{- end }}
       {{- if hasKey .Values.decode "enableServiceLinks" }}

--- a/charts/llm-d-modelservice/templates/decode-lws.yaml
+++ b/charts/llm-d-modelservice/templates/decode-lws.yaml
@@ -59,7 +59,7 @@ spec:
         initContainers:
         {{- (include "llm-d-modelservice.routingProxy" (dict "proxy" .Values.routing.proxy "servicePort" .Values.routing.servicePort "Values" .Values)) | nindent 8 }}
         {{- if .Values.decode.initContainers }}
-        {{- toYaml .Values.decode.initContainers | nindent 8 }}
+        {{- include "llm-d-modelservice.renderContainerList" (dict "containers" .Values.decode.initContainers "Values" .Values) | nindent 8 }}
         {{- end }}
         {{- end }}
         {{- if hasKey .Values.decode "enableServiceLinks" }}

--- a/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
+++ b/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
@@ -26,7 +26,7 @@ spec:
             initContainers:
             {{- (include "llm-d-modelservice.routingProxy" (dict "proxy" .Values.routing.proxy "servicePort" .Values.routing.servicePort "Values" .Values)) | nindent 12 }}
             {{- if .Values.decode.initContainers }}
-            {{- toYaml .Values.decode.initContainers | nindent 12 }}
+            {{- include "llm-d-modelservice.renderContainerList" (dict "containers" .Values.decode.initContainers "Values" .Values) | nindent 12 }}{{- toYaml .Values.decode.initContainers | nindent 12 }}
             {{- end }}
             {{- end }}
             {{- with .Values.decode.containers }}
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
         - name: inference-server
-          image: {{ .Values.requester.image }}
+          image: {{ include "llm-d-modelservice.resolveImage" (dict "image" .Values.requester.image "Values" .Values) | trim }}
           imagePullPolicy: Always
           command:
           - /app/requester

--- a/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
+++ b/charts/llm-d-modelservice/templates/decode-requester-replicaset.yaml
@@ -26,7 +26,7 @@ spec:
             initContainers:
             {{- (include "llm-d-modelservice.routingProxy" (dict "proxy" .Values.routing.proxy "servicePort" .Values.routing.servicePort "Values" .Values)) | nindent 12 }}
             {{- if .Values.decode.initContainers }}
-            {{- include "llm-d-modelservice.renderContainerList" (dict "containers" .Values.decode.initContainers "Values" .Values) | nindent 12 }}{{- toYaml .Values.decode.initContainers | nindent 12 }}
+            {{- include "llm-d-modelservice.renderContainerList" (dict "containers" .Values.decode.initContainers "Values" .Values) | nindent 12 }}
             {{- end }}
             {{- end }}
             {{- with .Values.decode.containers }}

--- a/charts/llm-d-modelservice/templates/prefill-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/prefill-deployment.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       {{- if .Values.prefill.initContainers }}
       initContainers:
-      {{- toYaml .Values.prefill.initContainers | nindent 8 }}
+      {{- include "llm-d-modelservice.renderContainerList" (dict "containers" .Values.prefill.initContainers "Values" .Values) | nindent 8 }}
       {{- end }}
       {{- if hasKey .Values.prefill "enableServiceLinks" }}
       enableServiceLinks: {{ .Values.prefill.enableServiceLinks }}

--- a/charts/llm-d-modelservice/templates/prefill-lws.yaml
+++ b/charts/llm-d-modelservice/templates/prefill-lws.yaml
@@ -57,7 +57,7 @@ spec:
         {{- end }}
         {{- if .Values.prefill.initContainers }}
         initContainers:
-        {{- toYaml .Values.prefill.initContainers | nindent 8 }}
+        {{- include "llm-d-modelservice.renderContainerList" (dict "containers" .Values.prefill.initContainers "Values" .Values) | nindent 8 }}
         {{- end }}
         {{- if hasKey .Values.prefill "enableServiceLinks" }}
         enableServiceLinks: {{ .Values.prefill.enableServiceLinks }}

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -1926,14 +1926,14 @@
             "title": "fullnameOverride"
         },
         "global": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "description": "Global values shared with subcharts",
             "properties": {
                 "imageRegistry": {
                     "default": "",
                     "description": "Override the registry for built-in chart workload images while preserving repository path and tag or digest Example: \"registry.example.com\" or \"registry.example.com/team-cache\"",
-                    "required": [],
-                    "title": "imageRegistry"
+                    "title": "imageRegistry",
+                    "type": "string"
                 }
             },
             "required": [],

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -1926,10 +1926,18 @@
             "title": "fullnameOverride"
         },
         "global": {
-            "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+            "additionalProperties": false,
+            "description": "Global values shared with subcharts",
+            "properties": {
+                "imageRegistry": {
+                    "default": "",
+                    "description": "Override the registry for built-in chart workload images while preserving repository path and tag or digest Example: \"registry.example.com\" or \"registry.example.com/team-cache\"",
+                    "required": [],
+                    "title": "imageRegistry"
+                }
+            },
             "required": [],
-            "title": "global",
-            "type": "object"
+            "title": "global"
         },
         "modelArtifacts": {
             "additionalProperties": false,

--- a/charts/llm-d-modelservice/values.schema.tmpl.json
+++ b/charts/llm-d-modelservice/values.schema.tmpl.json
@@ -612,10 +612,18 @@
       "title": "fullnameOverride"
     },
     "global": {
-      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "additionalProperties": false,
+      "description": "Global values shared with subcharts",
+      "properties": {
+        "imageRegistry": {
+          "default": "",
+          "description": "Override the registry for built-in chart workload images while preserving repository path and tag or digest Example: \"registry.example.com\" or \"registry.example.com/team-cache\"",
+          "required": [],
+          "title": "imageRegistry"
+        }
+      },
       "required": [],
-      "title": "global",
-      "type": "object"
+      "title": "global"
     },
     "modelArtifacts": {
       "additionalProperties": false,

--- a/charts/llm-d-modelservice/values.schema.tmpl.json
+++ b/charts/llm-d-modelservice/values.schema.tmpl.json
@@ -612,14 +612,14 @@
       "title": "fullnameOverride"
     },
     "global": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "Global values shared with subcharts",
       "properties": {
         "imageRegistry": {
           "default": "",
           "description": "Override the registry for built-in chart workload images while preserving repository path and tag or digest Example: \"registry.example.com\" or \"registry.example.com/team-cache\"",
-          "required": [],
-          "title": "imageRegistry"
+          "title": "imageRegistry",
+          "type": "string"
         }
       },
       "required": [],

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -9,6 +9,12 @@
 # -- Common configuration values
 common: {}
 
+# -- Global values shared with subcharts
+global:
+  # -- Override the registry for built-in chart workload images while preserving repository path and tag or digest
+  # Example: "registry.example.com" or "registry.example.com/team-cache"
+  imageRegistry: ""
+
 # -- Usually used when using llm-d-modelservice as a subchart
 enabled: true
 

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -9,8 +9,14 @@
 # -- Common configuration values
 common: {}
 
+# @schema
+# additionalProperties: true
+# @schema
 # -- Global values shared with subcharts
 global:
+  # @schema
+  # type: string
+  # @schema
   # -- Override the registry for built-in chart workload images while preserving repository path and tag or digest
   # Example: "registry.example.com" or "registry.example.com/team-cache"
   imageRegistry: ""

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-dra.yaml
+++ b/examples/output-dra.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: dra-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: dra-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -115,7 +115,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: intel-gaudi-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-gaudi.yaml
+++ b/examples/output-gaudi.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: gaudi-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: gaudi-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-heterogeneous-pd.yaml
+++ b/examples/output-heterogeneous-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: heterogeneous-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,7 +132,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -225,7 +225,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: nvidia-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-image-registry-override.yaml
+++ b/examples/output-image-registry-override.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: pd-mnnvl-llm-d-modelservice
+  name: img-override-llm-d-modelservice
   labels:
     helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
@@ -14,7 +14,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: pd-mnnvl-llm-d-modelservice-decode
+  name: img-override-llm-d-modelservice-decode
   labels:
     helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
@@ -42,7 +42,7 @@ spec:
             - --zap-encoder=json
             - --zap-log-level=debug
             - --secure-proxy=false
-          image: ghcr.io/llm-d/llm-d-routing-sidecar:latest
+          image: registry.example.com/llm-d/llm-d-routing-sidecar:latest
           imagePullPolicy: Always
           env:
           ports:
@@ -52,8 +52,13 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+        - command:
+          - echo
+          - init
+          image: registry.example.com/llm-d/init-helper:latest
+          name: init-download
     
-      serviceAccountName: pd-mnnvl-llm-d-modelservice
+      serviceAccountName: img-override-llm-d-modelservice
       
       volumes:
         - emptyDir: {}
@@ -63,12 +68,10 @@ spec:
           emptyDir:
             sizeLimit: 20Gi
         
-      resourceClaims:
-        - name: llm-d-imex-channel-0
-          resourceClaimTemplateName: llm-d-imex-channel-0
+      
       containers:
         - name: vllm
-          image: ghcr.io/llm-d/llm-d-cuda:latest
+          image: registry.example.com/llm-d/llm-d-cuda:latest
           
           command: ["vllm", "serve"]
           args:
@@ -119,8 +122,6 @@ spec:
               cpu: "16"
               memory: 16Gi
               nvidia.com/gpu: "1"
-            claims:
-              - name: llm-d-imex-channel-0
           
           volumeMounts:
             - name: model-storage
@@ -130,7 +131,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: pd-mnnvl-llm-d-modelservice-prefill
+  name: img-override-llm-d-modelservice-prefill
   labels:
     helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
@@ -149,8 +150,14 @@ spec:
         llm-d.ai/model: facebook-opt-125m
         llm-d.ai/role: prefill
     spec:
+      initContainers:
+        - command:
+          - echo
+          - init
+          image: registry.example.com/library/busybox:latest
+          name: init-download
     
-      serviceAccountName: pd-mnnvl-llm-d-modelservice
+      serviceAccountName: img-override-llm-d-modelservice
       
       volumes:
         - emptyDir: {}
@@ -160,12 +167,10 @@ spec:
           emptyDir:
             sizeLimit: 20Gi
         
-      resourceClaims:
-        - name: llm-d-imex-channel-0
-          resourceClaimTemplateName: llm-d-imex-channel-0
+      
       containers:
         - name: vllm
-          image: ghcr.io/llm-d/llm-d-cuda:latest
+          image: registry.example.com/llm-d/llm-d-cuda:latest
           
           command: ["vllm", "serve"]
           args:
@@ -216,8 +221,6 @@ spec:
               cpu: "16"
               memory: 16Gi
               nvidia.com/gpu: "1"
-            claims:
-              - name: llm-d-imex-channel-0
           
           volumeMounts:
             - name: model-storage

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -128,7 +128,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -128,7 +128,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -127,7 +127,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-rebellions-atom.yaml
+++ b/examples/output-rebellions-atom.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: rebellions-atom-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: rebellions-atom-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-requester.yaml
+++ b/examples/output-requester.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: requester-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -143,7 +143,7 @@ kind: Deployment
 metadata:
   name: requester-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu-pd.yaml
+++ b/examples/output-xpu-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -159,7 +159,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu.yaml
+++ b/examples/output-xpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/values-image-registry-override.yaml
+++ b/examples/values-image-registry-override.yaml
@@ -1,0 +1,114 @@
+# This values.yaml demonstrates global.imageRegistry override
+# Based on values-pd.yaml with a custom registry prefix to redirect all images
+# to a private registry without rewriting container image references.
+# See also defaults in chart values.yaml
+
+global:
+  imageRegistry: "registry.example.com"
+
+# When true, LeaderWorkerSet is used instead of Deployment
+multinode: false
+
+modelArtifacts:
+# This is the model name used to start vLLM.
+  name: facebook/opt-125m
+  labels:
+    llm-d.ai/inference-serving: "true"
+    llm-d.ai/model: facebook-opt-125m
+  uri: hf://"{{ .Values.modelArtifacts.name }}"
+  size: 20Gi
+
+# Describe routing requirements. In addition to service level routing (OpenAI model name, service port)
+# also describes elements for Gateway API Inference Extension configuration
+routing:
+  servicePort: 8000
+
+  # other fields are inherited from chart values.yaml
+  proxy:
+    secure: false
+
+# Decode pod configuation
+decode:
+  create: true
+  replicas: 1
+  initContainers:
+  - name: "init-download"
+    image: "ghcr.io/llm-d/init-helper:latest"
+    command: ["echo", "init"]
+  containers:
+  - name: "vllm"
+    image: "ghcr.io/llm-d/llm-d-cuda:latest"
+    modelCommand: vllmServe
+    args:
+      - "--enforce-eager"
+      - "--kv-transfer-config"
+      - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+    env:
+      - name: CUDA_VISIBLE_DEVICES
+        value: "0"
+      - name: UCX_TLS
+        value: "cuda_ipc,cuda_copy,tcp"
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+        value: "5600"
+      - name: VLLM_LOGGING_LEVEL
+        value: DEBUG
+    ports:
+      - containerPort: 8200  # from routing.proxy.targetPort
+        protocol: TCP
+      - containerPort: 5600  # NIXL side channel
+        protocol: TCP
+    resources:
+      limits:
+        memory: 16Gi
+        cpu: "16"
+      requests:
+        cpu: "16"
+        memory: 16Gi
+    mountModelVolume: true
+
+# Prefill pod configuation
+prefill:
+  create: true
+  replicas: 1
+  initContainers:
+  - name: "init-download"
+    image: "docker.io/library/busybox:latest"
+    command: ["echo", "init"]
+  containers:
+  - name: "vllm"
+    image: "ghcr.io/llm-d/llm-d-cuda:latest"
+    modelCommand: vllmServe
+    args:
+      - "--enforce-eager"
+      - "--kv-transfer-config"
+      - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+    env:
+      - name: CUDA_VISIBLE_DEVICES
+        value: "0"
+      - name: UCX_TLS
+        value: "cuda_ipc,cuda_copy,tcp"
+      - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+        value: "5600"
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      - name: VLLM_LOGGING_LEVEL
+        value: DEBUG
+    ports:
+      - containerPort: 8000  # from routing.servicePort
+        protocol: TCP
+      - containerPort: 5600  # NIXL side channel
+        protocol: TCP
+    resources:
+      limits:
+        memory: 16Gi
+        cpu: "16"
+      requests:
+        cpu: "16"
+        memory: 16Gi
+    mountModelVolume: true

--- a/hack/generate-example-output.sh
+++ b/hack/generate-example-output.sh
@@ -51,3 +51,6 @@ generate_output "pvc-hf" "examples/values-pd.yaml" "examples/output-pvc-hf.yaml"
 
 # Generate output-rebellions-atom.yaml (Rebellions ATOM deployment)
 generate_output "rebellions-atom" "examples/values-rebellions-atom.yaml" "examples/output-rebellions-atom.yaml"
+
+# Generate output-image-registry-override.yaml (Global image registry override)
+generate_output "img-override" "examples/values-image-registry-override.yaml" "examples/output-image-registry-override.yaml"


### PR DESCRIPTION
### Summary
Adds a Bitnami-style `global.imageRegistry` override to redirect all images (decode, prefill, etc.) to a private registry without rewriting container lists. 

Closes #157

### Changes
Added `global.imageRegistry` value.
Added centralized image resolution helper.
Applied override to decode/prefill containers, initContainers, routing proxy, and requester image.

### Notes
Backward compatible: if `global.imageRegistry` is unset, existing behavior is unchanged.
Regenerated schema/output files and passed pre-commit checks.


