### PR TITLE
feat: support composing multiple DRA resource claim templates

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "v0.4.9"
+version: "v0.4.10"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/llm-d-modelservice/templates/_helpers-dra.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers-dra.tpl
@@ -112,7 +112,33 @@ false
 {{- $count -}}
 {{- end }}
 
-{{/* Generate resourceClaims Variable (merges accelerator + user-defined claims) */}}
+{{/* Get claim name for an additional resource claim template */}}
+{{- define "llm-d-modelservice.additionalClaimName" -}}
+{{- $templateKey := .templateKey -}}
+{{- $role := .role | default "" -}}
+{{- $config := .config -}}
+{{- $baseName := $config.name | default (printf "%s-claim-template" $templateKey) -}}
+{{- if $role -}}
+  {{- printf "%s-%s-claim" (trimSuffix "-claim-template" $baseName) $role -}}
+{{- else -}}
+  {{- printf "%s-claim" (trimSuffix "-claim-template" $baseName) -}}
+{{- end -}}
+{{- end }}
+
+{{/* Get claim template name for an additional resource claim template */}}
+{{- define "llm-d-modelservice.additionalClaimTemplateName" -}}
+{{- $templateKey := .templateKey -}}
+{{- $role := .role | default "" -}}
+{{- $config := .config -}}
+{{- $baseName := $config.name | default (printf "%s-claim-template" $templateKey) -}}
+{{- if $role -}}
+  {{- printf "%s-%s" $baseName $role -}}
+{{- else -}}
+  {{- $baseName -}}
+{{- end -}}
+{{- end }}
+
+{{/* Generate resourceClaims Variable (merges accelerator + additional + user-defined claims) */}}
 {{- define "llm-d-modelservice.resourceClaimsBase" -}}
 {{- $claims := list -}}
 {{- $draEnabled := eq (include "llm-d-modelservice.draEnabled" .) "true" -}}
@@ -120,6 +146,18 @@ false
   {{- $claimName := include "llm-d-modelservice.acceleratorClaimName" . -}}
   {{- $templateName := include "llm-d-modelservice.acceleratorClaimTemplateName" . -}}
   {{- $claims = append $claims (dict "name" $claimName "resourceClaimTemplateName" $templateName) -}}
+
+  {{- /* Add claims for additional resource claim templates (e.g., RDMA) */}}
+  {{- $additionalTemplates := .Values.accelerator.additionalResourceClaimTemplates | default list -}}
+  {{- range $templateKey := $additionalTemplates -}}
+    {{- if hasKey $.Values.accelerator.resourceClaimTemplates $templateKey -}}
+      {{- $config := index $.Values.accelerator.resourceClaimTemplates $templateKey -}}
+      {{- $ctx := dict "templateKey" $templateKey "role" $.role "config" $config -}}
+      {{- $addClaimName := include "llm-d-modelservice.additionalClaimName" $ctx -}}
+      {{- $addTemplateName := include "llm-d-modelservice.additionalClaimTemplateName" $ctx -}}
+      {{- $claims = append $claims (dict "name" $addClaimName "resourceClaimTemplateName" $addTemplateName) -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 {{- if .pdSpec.resourceClaims -}}
   {{- $claims = concat $claims .pdSpec.resourceClaims -}}

--- a/charts/llm-d-modelservice/templates/resource-claim-template.yaml
+++ b/charts/llm-d-modelservice/templates/resource-claim-template.yaml
@@ -65,6 +65,42 @@ spec:
           {{- toYaml $selectors | nindent 10 }}
           {{- end }}
       {{- end -}}
+
+      {{- /* Generate ResourceClaimTemplates for additional resources (e.g., RDMA) */}}
+      {{- $additionalTemplates := $.Values.accelerator.additionalResourceClaimTemplates | default list -}}
+      {{- range $templateKey := $additionalTemplates -}}
+        {{- if hasKey $.Values.accelerator.resourceClaimTemplates $templateKey -}}
+          {{- $addConfig := index $.Values.accelerator.resourceClaimTemplates $templateKey -}}
+          {{- $addCtx := dict "templateKey" $templateKey "role" $role.name "config" $addConfig -}}
+          {{- $addTemplateName := include "llm-d-modelservice.additionalClaimTemplateName" $addCtx -}}
+
+          {{- $addCount := $addConfig.count | default 1 -}}
+          {{- $addClass := $addConfig.class | default $templateKey -}}
+          {{- $addMatch := $addConfig.match | default "exactly" -}}
+          {{- $addSelectors := $addConfig.selectors | default list -}}
+          {{- $addRequestName := $addConfig.requestName | default $templateKey }}
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: {{ $addTemplateName }}
+  labels:
+    {{- include "llm-d-modelservice.labels" $ | nindent 4 }}
+    llm-d.ai/role: {{ $role.name }}
+spec:
+  spec:
+    devices:
+      requests:
+      - name: {{ $addRequestName }}
+        {{ $addMatch }}:
+          deviceClassName: {{ $addClass }}
+          count: {{ $addCount }}
+          {{- if $addSelectors }}
+          selectors:
+          {{- toYaml $addSelectors | nindent 10 }}
+          {{- end }}
+        {{- end -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end }}

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -6,6 +6,14 @@
             "additionalProperties": false,
             "description": " Supported types: nvidia, intel-i915, intel-xe, intel-gaudi, amd, google, cpu",
             "properties": {
+                "additionalResourceClaimTemplates": {
+                    "description": " Each entry references a key in accelerator.resourceClaimTemplates below. This allows composing multiple device types (e.g., GPU + RDMA) for a single workload. Example:   additionalResourceClaimTemplates:     - rdma",
+                    "items": {
+                        "required": []
+                    },
+                    "required": [],
+                    "title": "additionalResourceClaimTemplates"
+                },
                 "dra": {
                     "default": false,
                     "description": " type: boolean @schema Enable Dynamic Resource Allocation (DRA) for accelerators When true, uses resourceClaimTemplates instead of device plugin resources",
@@ -109,7 +117,7 @@
                 },
                 "resourceClaimTemplates": {
                     "additionalProperties": false,
-                    "description": " Each accelerator type can have its own claim template configuration",
+                    "description": " Each accelerator type can have its own claim template configuration. Custom entries can be added here and referenced via additionalResourceClaimTemplates.",
                     "properties": {
                         "amd": {
                             "additionalProperties": false,
@@ -320,6 +328,41 @@
                             },
                             "required": [],
                             "title": "nvidia",
+                            "type": "object"
+                        },
+                        "rdma": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "class": {
+                                    "default": "rdma-dranet",
+                                    "title": "class",
+                                    "type": "string"
+                                },
+                                "count": {
+                                    "default": 1,
+                                    "title": "count",
+                                    "type": "integer"
+                                },
+                                "match": {
+                                    "default": "exactly",
+                                    "title": "match",
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "default": "rdma-claim-template",
+                                    "title": "name",
+                                    "type": "string"
+                                },
+                                "selectors": {
+                                    "items": {
+                                        "required": []
+                                    },
+                                    "title": "selectors",
+                                    "type": "array"
+                                }
+                            },
+                            "required": [],
+                            "title": "rdma",
                             "type": "object"
                         }
                     },

--- a/charts/llm-d-modelservice/values.schema.tmpl.json
+++ b/charts/llm-d-modelservice/values.schema.tmpl.json
@@ -6,6 +6,14 @@
       "additionalProperties": false,
       "description": " Supported types: nvidia, intel-i915, intel-xe, intel-gaudi, amd, google, cpu",
       "properties": {
+        "additionalResourceClaimTemplates": {
+          "description": " Each entry references a key in accelerator.resourceClaimTemplates below. This allows composing multiple device types (e.g., GPU + RDMA) for a single workload. Example:   additionalResourceClaimTemplates:     - rdma",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "additionalResourceClaimTemplates"
+        },
         "dra": {
           "default": false,
           "description": " type: boolean @schema Enable Dynamic Resource Allocation (DRA) for accelerators When true, uses resourceClaimTemplates instead of device plugin resources",
@@ -109,7 +117,7 @@
         },
         "resourceClaimTemplates": {
           "additionalProperties": false,
-          "description": " Each accelerator type can have its own claim template configuration",
+          "description": " Each accelerator type can have its own claim template configuration. Custom entries can be added here and referenced via additionalResourceClaimTemplates.",
           "properties": {
             "amd": {
               "additionalProperties": false,
@@ -320,6 +328,41 @@
               },
               "required": [],
               "title": "nvidia",
+              "type": "object"
+            },
+            "rdma": {
+              "additionalProperties": false,
+              "properties": {
+                "class": {
+                  "default": "rdma-dranet",
+                  "title": "class",
+                  "type": "string"
+                },
+                "count": {
+                  "default": 1,
+                  "title": "count",
+                  "type": "integer"
+                },
+                "match": {
+                  "default": "exactly",
+                  "title": "match",
+                  "type": "string"
+                },
+                "name": {
+                  "default": "rdma-claim-template",
+                  "title": "name",
+                  "type": "string"
+                },
+                "selectors": {
+                  "items": {
+                    "required": []
+                  },
+                  "title": "selectors",
+                  "type": "array"
+                }
+              },
+              "required": [],
+              "title": "rdma",
               "type": "object"
             }
           },

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -111,8 +111,16 @@ accelerator:
     intel-xe:
       - name: VLLM_WORKER_MULTIPROC_METHOD
         value: "spawn"
+  # Additional DRA resource claim templates to include alongside the primary accelerator.
+  # Each entry references a key in accelerator.resourceClaimTemplates below.
+  # This allows composing multiple device types (e.g., GPU + RDMA) for a single workload.
+  # Example:
+  #   additionalResourceClaimTemplates:
+  #     - rdma
+  additionalResourceClaimTemplates: []
   # ResourceClaimTemplate configurations for DRA (used when dra: true)
-  # Each accelerator type can have its own claim template configuration
+  # Each accelerator type can have its own claim template configuration.
+  # Custom entries can be added here and referenced via additionalResourceClaimTemplates.
   resourceClaimTemplates:
     nvidia:
       name: nvidia-claim-template
@@ -149,6 +157,12 @@ accelerator:
       name: google-claim-template
       class: tpu.google.com
       match: "exactly"
+      selectors: []
+    rdma:
+      name: rdma-claim-template
+      class: rdma-dranet
+      match: "exactly"
+      count: 1
       selectors: []
 
 # @schema

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-dra.yaml
+++ b/examples/output-dra.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: dra-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: dra-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -115,7 +115,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: intel-gaudi-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-gaudi.yaml
+++ b/examples/output-gaudi.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: gaudi-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: gaudi-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-heterogeneous-pd.yaml
+++ b/examples/output-heterogeneous-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: heterogeneous-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,7 +132,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -225,7 +225,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: nvidia-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-pd-mnnvl.yaml
+++ b/examples/output-pd-mnnvl.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-mnnvl-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,7 +132,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -128,7 +128,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -128,7 +128,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -127,7 +127,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-requester.yaml
+++ b/examples/output-requester.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: requester-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -143,7 +143,7 @@ kind: Deployment
 metadata:
   name: requester-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu-pd.yaml
+++ b/examples/output-xpu-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -159,7 +159,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu.yaml
+++ b/examples/output-xpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.9
+    helm.sh/chart: llm-d-modelservice-v0.4.10
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:


### PR DESCRIPTION
Related to #237. I think this is a more general refactor and not tied as much to the XPU RDMA case, but still supports it

cc @kalantar @VincyZhang - let me know if this works for your use case

Changes:
  - Adds `accelerator.additionalResourceClaimTemplates` — a list of keys referencing entries in `accelerator.resourceClaimTemplates` to include alongside the primary accelerator (e.g., RDMA alongside GPUs)
  - Opens `resourceClaimTemplates` schema to accept user-defined entries (`additionalProperties`), so users can define custom device classes without chart changes
  - Adds a built-in `rdma` template entry (`rdma-dranet` device class) as a ready-to-use example
  - Each additional template gets its own role-scoped `ResourceClaimTemplate` and pod `resourceClaim`, matching the existing pattern for the primary accelerator
  
This allows us to do stuff like:

  ```yaml
  accelerator:
    type: intel
    dra: true
    additionalResourceClaimTemplates:
      - rdma
      - my-custom-device
    resourceClaimTemplates:
      my-custom-device:
        name: my-device-template
        class: device.vendor.com
        match: "exactly"
        count: 2
```
Meaning we can maintain the default templates but also not have to wait for a PR to support new templates