### PR TITLE
Make Deployment strategy configurable

### DIFF
--- a/charts/llm-d-modelservice/templates/decode-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/decode-deployment.yaml
@@ -21,6 +21,10 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ ternary .Values.decode.replicas 1 (hasKey .Values.decode "replicas") }}
+  {{- if .Values.decode.strategy }}
+  strategy:
+    {{- toYaml .Values.decode.strategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "llm-d-modelservice.decodelabels" . | nindent 6 }}

--- a/charts/llm-d-modelservice/templates/prefill-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/prefill-deployment.yaml
@@ -21,6 +21,10 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ ternary .Values.prefill.replicas 1 (hasKey .Values.prefill "replicas") }}
+  {{- if .Values.prefill.strategy }}
+  strategy:
+    {{- toYaml .Values.prefill.strategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "llm-d-modelservice.prefilllabels" . | nindent 6 }}

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -249,6 +249,21 @@ decode:
     enabled: false
 
   replicas: 1
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # @schema
+  # -- Deployment strategy configuration for decode pods.
+  # -- Defaults to Kubernetes default if not specified.
+  # -- Example:
+  # --   strategy:
+  # --     type: RollingUpdate
+  # --     rollingUpdate:
+  # --       maxSurge: 0
+  # --       maxUnavailable: 1
+  # strategy: {}
+
   # @schema
   # additionalProperties: true
   # @schema
@@ -463,6 +478,21 @@ prefill:
     enabled: false
 
   replicas: 0
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # @schema
+  # -- Deployment strategy configuration for prefill pods.
+  # -- Defaults to Kubernetes default if not specified.
+  # -- Example:
+  # --   strategy:
+  # --     type: RollingUpdate
+  # --     rollingUpdate:
+  # --       maxSurge: 0
+  # --       maxUnavailable: 1
+  # strategy: {}
+
   # @schema
   # additionalProperties: true
   # @schema


### PR DESCRIPTION
There was no option to change the deployment strategy from the default `RollingUpdate` with the default configuration.