### PR TITLE
Allow configurable modelArtifacts readOnly for PVC mounts

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "v0.4.11"
+version: "v0.4.12"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -373,7 +373,7 @@ Context is .Values.modelArtifacts
 - name: model-storage
   persistentVolumeClaim:
     claimName: {{ $claim }}
-    readOnly: true
+    readOnly: {{ .readOnly }}
 {{- else if eq $protocol "oci" }}
 - name: model-storage
   image:
@@ -398,12 +398,13 @@ volumeMounts:
 {{- if .container.mountModelVolume }}
   - name: model-storage
     mountPath: {{ .Values.modelArtifacts.mountPath }}
-{{- /* enforce readOnly volumeMounts for OCI and PVCs */}}
+{{- /* OCI always readOnly; PVC variants use modelArtifacts.readOnly */}}
 {{- $parsedArtifacts := regexSplit "://" .Values.modelArtifacts.uri -1 -}}
 {{- $protocol := first $parsedArtifacts -}}
-{{- $path := last $parsedArtifacts -}}
-{{- if or (eq $protocol "oci") (eq $protocol "pvc") }}
+{{- if eq $protocol "oci" }}
     readOnly: true
+{{- else if hasPrefix "pvc" $protocol }}
+    readOnly: {{ .Values.modelArtifacts.readOnly }}
 {{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -1966,6 +1966,12 @@
                     "required": [],
                     "title": "name"
                 },
+                "readOnly": {
+                    "default": true,
+                    "description": " type: boolean @schema Whether PVC-backed model mounts (pvc:// and pvc+hf://) should be read-only. Set to false for pvc+hf:// when Hugging Face cache writes are needed; other URI schemes ignore this setting.",
+                    "title": "readOnly",
+                    "type": "boolean"
+                },
                 "size": {
                     "default": "5Mi",
                     "description": "size of volume to create to hold the model",

--- a/charts/llm-d-modelservice/values.schema.tmpl.json
+++ b/charts/llm-d-modelservice/values.schema.tmpl.json
@@ -652,6 +652,12 @@
           "required": [],
           "title": "name"
         },
+        "readOnly": {
+          "default": true,
+          "description": " type: boolean @schema Whether PVC-backed model mounts (pvc:// and pvc+hf://) should be read-only. Set to false for pvc+hf:// when Hugging Face cache writes are needed; other URI schemes ignore this setting.",
+          "title": "readOnly",
+          "type": "boolean"
+        },
         "size": {
           "default": "5Mi",
           "description": "size of volume to create to hold the model",

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -76,6 +76,12 @@ modelArtifacts:
   authSecretName: ""
   # location where model volume will be mounted (used when mountModelVolume: true)
   mountPath: /model-cache
+  # @schema
+  # type: boolean
+  # @schema
+  # Whether PVC-backed model mounts (pvc:// and pvc+hf://) should be read-only.
+  # Set to false for pvc+hf:// when Hugging Face cache writes are needed; other URI schemes ignore this setting.
+  readOnly: true
 
 # When true, a LeaderWorkerSet is used instead of a Deployment
 multinode: false

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-dra.yaml
+++ b/examples/output-dra.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: dra-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: dra-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -108,6 +108,7 @@ spec:
           volumeMounts:
             - name: model-storage
               mountPath: /model-cache
+              readOnly: true
 ---
 # Source: llm-d-modelservice/templates/resource-claim-template.yaml
 apiVersion: resource.k8s.io/v1
@@ -115,7 +116,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: intel-gaudi-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-gaudi.yaml
+++ b/examples/output-gaudi.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: gaudi-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: gaudi-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -101,3 +101,4 @@ spec:
           volumeMounts:
             - name: model-storage
               mountPath: /model-cache
+              readOnly: true

--- a/examples/output-heterogeneous-pd.yaml
+++ b/examples/output-heterogeneous-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: heterogeneous-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,7 +132,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -225,7 +225,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: nvidia-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-pd-mnnvl.yaml
+++ b/examples/output-pd-mnnvl.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-mnnvl-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,7 +132,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -128,7 +128,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -121,6 +121,7 @@ spec:
           volumeMounts:
             - name: model-storage
               mountPath: /model-cache
+              readOnly: true
 ---
 # Source: llm-d-modelservice/templates/prefill-deployment.yaml
 apiVersion: apps/v1
@@ -128,7 +129,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -214,3 +215,4 @@ spec:
           volumeMounts:
             - name: model-storage
               mountPath: /model-cache
+              readOnly: true

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -127,7 +127,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-rebellions-atom.yaml
+++ b/examples/output-rebellions-atom.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: rebellions-atom-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: rebellions-atom-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-requester.yaml
+++ b/examples/output-requester.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: requester-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -143,7 +143,7 @@ kind: Deployment
 metadata:
   name: requester-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu-pd.yaml
+++ b/examples/output-xpu-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -159,7 +159,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu.yaml
+++ b/examples/output-xpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.11
+    helm.sh/chart: llm-d-modelservice-v0.4.12
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/pvc/README.md
+++ b/examples/pvc/README.md
@@ -86,8 +86,8 @@ Note that the path after the `<pvc-name>` is the path on the PVC which the downl
 Make sure that for the container of your interst in `prefill.containers` or `decode.containers`, there's a field called `mountModelVolume: true` ([see example](../values-pd.yaml#L87)) for the volume mounts to be created correctly.
 
 ### Behavior
-- A read-only PVC volume with the name `model-storage` is created for the deployment
-- A read-only volumeMount with the mountPath: `model-cache` is created for each container where `mountModelVolume: true`
+- A PVC volume with the name `model-storage` is created for the deployment (read-only by default)
+- A volumeMount with the mountPath: `model-cache` is created for each container where `mountModelVolume: true` (read-only by default; set `modelArtifacts.readOnly: false` to allow writes)
 - `--model` arg for that container is set to `model-cache/<path/to/model>` where `mountModelVolume: true`
 
 ⚠️ You do **not** need to configure volumeMounts for containers where  `mountModelVolume: true`. ModelService will automatically populate the pod specification and mount the model files.
@@ -96,7 +96,7 @@ However, if you want to add your own volume specifications, you may do so under 
 
 💡 You may optionally set the `--served-model-name`  in your container to be used for the OpenAI request, otherwise the request name must be a long string like `"model": "model-cache/<path/to/model>"`. Note that this argument is added automatically using the option `modelCommand: vllmServe` or `imageDefault`, using `routing.modelName` as the value to the `--served-model-name` argument.
 
-> For security purposes, a read-only volume is mounted to the pods to prevent a pod from deleting the model files in case another model service installation uses the same PVC. If you would like to write to the PVC, you should not do so through ModelService, but rather through your own pod like the download-model/pvc-debugger without the read-only restriction.
+> For security purposes, the default is a read-only volume mount to the pods to prevent a pod from deleting the model files in case another model service installation uses the same PVC. If you would like to write to the PVC, you should not do so through ModelService, but rather through your own pod like the download-model/pvc-debugger without the read-only restriction. Alternatively, set `modelArtifacts.readOnly: false` if write access is required (for example, Hugging Face cache lock files with `pvc+hf://`).
 
 
 ## Use HF-downloaded models with PVCs
@@ -121,7 +121,15 @@ helm install pvc-hf-example llm-d-modelservice/llm-d-modelservice \
 Make sure that for the container of your interst in `prefill.containers` or `decode.containers`, there's a field called `mountModelVolume: true` ([see example](../values-pd.yaml#L87)) for the volume mounts to be created correctly.
 
 ### Behavior
-- A read-only PVC volume with the name `model-storage` is created for the deployment
-- A read-only volumeMount with the mountPath: `model-cache` is created for each container where `mountModelVolume: true`
+- A PVC volume with the name `model-storage` is created for the deployment (read-only by default)
+- A volumeMount with the mountPath: `model-cache` is created for each container where `mountModelVolume: true` (read-only by default; set `modelArtifacts.readOnly: false` to allow writes)
 - `HF_HUB_CACHE` environment variable for that container is set to `model-cache/path/to/hf_hub_cache` where `mountModelVolume: true`
 - `--model` arugment is set to `facebook/opt-125m`
+
+> **Note:** Hugging Face Hub needs to write `.lock` files and cache metadata. Set `modelArtifacts.readOnly: false` to allow writes:
+>
+> ```yaml
+> modelArtifacts:
+>   uri: pvc+hf://pvc-name/path/to/hf_hub_cache/namespace/modelID
+>   readOnly: false
+> ```


### PR DESCRIPTION
## What does this PR do?

Add a `modelArtifacts.readOnly` field (default `true`) to control whether PVC model volumes are mounted read-only. Users can set it to `false` when write access is needed (e.g. `pvc+hf://` with HuggingFace cache).

## Why is this change needed?

The chart hardcodes `readOnly: true` on all PVC mounts, breaking `pvc+hf://` deployments where HuggingFace Hub needs to write `.lock` files and cache metadata.

## How was this tested?

- [x] Manual testing performed

`helm template` verified for `pvc://`, `pvc+hf://`, and `hf://` with default and override values. `helm lint` passes. Example outputs regenerated.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

- https://github.com/llm-d-incubation/llm-d-modelservice/issues/243