### PR TITLE
Fixes failing CI on pre-commit and lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin
 *.tmp
 *.orig
 *~
+charts/llm-d-modelservice/charts/

--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "v0.4.10"
+version: "v0.4.11"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -1833,7 +1833,7 @@
                 },
                 "nodeSelector": {
                     "additionalProperties": true,
-                    "description": " additionalProperties: true @schema",
+                    "description": "maxUnavailable: 1 strategy: {} @schema additionalProperties: true @schema",
                     "required": [],
                     "title": "nodeSelector"
                 },
@@ -3436,7 +3436,7 @@
                 },
                 "nodeSelector": {
                     "additionalProperties": true,
-                    "description": " additionalProperties: true @schema",
+                    "description": "maxUnavailable: 1 strategy: {} @schema additionalProperties: true @schema",
                     "required": [],
                     "title": "nodeSelector"
                 },

--- a/charts/llm-d-modelservice/values.schema.tmpl.json
+++ b/charts/llm-d-modelservice/values.schema.tmpl.json
@@ -519,7 +519,7 @@
         },
         "nodeSelector": {
           "additionalProperties": true,
-          "description": " additionalProperties: true @schema",
+          "description": "maxUnavailable: 1 strategy: {} @schema additionalProperties: true @schema",
           "required": [],
           "title": "nodeSelector"
         },
@@ -808,7 +808,7 @@
         },
         "nodeSelector": {
           "additionalProperties": true,
-          "description": " additionalProperties: true @schema",
+          "description": "maxUnavailable: 1 strategy: {} @schema additionalProperties: true @schema",
           "required": [],
           "title": "nodeSelector"
         },

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-dra.yaml
+++ b/examples/output-dra.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: dra-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: dra-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -115,7 +115,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: intel-gaudi-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-gaudi.yaml
+++ b/examples/output-gaudi.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: gaudi-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: gaudi-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-heterogeneous-pd.yaml
+++ b/examples/output-heterogeneous-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: heterogeneous-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,7 +132,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -225,7 +225,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: nvidia-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-pd-mnnvl.yaml
+++ b/examples/output-pd-mnnvl.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-mnnvl-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,7 +132,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -128,7 +128,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -128,7 +128,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -127,7 +127,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-rebellions-atom.yaml
+++ b/examples/output-rebellions-atom.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: rebellions-atom-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: rebellions-atom-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-requester.yaml
+++ b/examples/output-requester.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: requester-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -143,7 +143,7 @@ kind: Deployment
 metadata:
   name: requester-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu-pd.yaml
+++ b/examples/output-xpu-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -159,7 +159,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu.yaml
+++ b/examples/output-xpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.10
+    helm.sh/chart: llm-d-modelservice-v0.4.11
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:


### PR DESCRIPTION
## What does this PR do?

Fixes failing CI on https://github.com/llm-d-incubation/llm-d-modelservice/pull/247 which was merged in by github-actions bot before CI finished running. 

## How was this tested?

- Regenerate `values.schema.json` and `values.schema.tmpl.json` to include the `deploymentStrategy` fields added in #247 (the `helm-schema` and `jsonschema-dereference` pre-commit hooks were never run before merge)
- Add `charts/llm-d-modelservice/charts/` to `.gitignore` to prevent Helm dependency charts (e.g. Bitnami `common`) from being tracked or linted by pre-commit

Fixes the two failing CI checks from #247:
- `Pre-commit` (helm-schema and jsonschema-dereference hooks)
- `Lint and Test Charts` (ct lint fails when schema is stale)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`make pre-commit-run`)
- [x] Linters pass (`make lint`)
- [x] Generated examples are in sync (`make verify`)
- [x] Chart version bumped (`make bump-chart-version-{patch|minor|major}`)
- [x] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
