### PR TITLE
fix chart routing proxy env when tracing disabled

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "v0.4.12"
+version: "v0.4.13"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/llm-d-modelservice/templates/_helpers.tpl
+++ b/charts/llm-d-modelservice/templates/_helpers.tpl
@@ -125,8 +125,8 @@ affinity:
     {{- end }}
   image: {{ required "routing.proxy.image must be specified" .proxy.image }}
   imagePullPolicy: {{ default "Always" .proxy.imagePullPolicy }}
-  env:
 {{- if and .Values.tracing .Values.tracing.enabled }}
+  env:
     - name: OTEL_SERVICE_NAME
       value: {{ .Values.tracing.serviceNames.routingProxy | quote }}
     - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -480,7 +480,7 @@
                                                     "description": "Selects a key from a ConfigMap.",
                                                     "properties": {
                                                         "key": {
-                                                            "description": "The key to select.",
+                                                            "description": "The key to select from the ConfigMap's Data field. Keys in the BinaryData field are not currently propagated to container env vars.",
                                                             "type": "string"
                                                         },
                                                         "name": {
@@ -617,7 +617,7 @@
                                     "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
                                     "properties": {
                                         "configMapRef": {
-                                            "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+                                            "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables. Keys in the BinaryData field are not currently propagated to container env vars.",
                                             "properties": {
                                                 "name": {
                                                     "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
@@ -1707,7 +1707,7 @@
                                     "description": "VolumeMount describes a mounting of a Volume within a container.",
                                     "properties": {
                                         "mountPath": {
-                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                            "description": "Path within the container at which the volume should be mounted.",
                                             "type": "string"
                                         },
                                         "mountPropagation": {
@@ -2089,7 +2089,7 @@
                                                     "description": "Selects a key from a ConfigMap.",
                                                     "properties": {
                                                         "key": {
-                                                            "description": "The key to select.",
+                                                            "description": "The key to select from the ConfigMap's Data field. Keys in the BinaryData field are not currently propagated to container env vars.",
                                                             "type": "string"
                                                         },
                                                         "name": {
@@ -2226,7 +2226,7 @@
                                     "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
                                     "properties": {
                                         "configMapRef": {
-                                            "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+                                            "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables. Keys in the BinaryData field are not currently propagated to container env vars.",
                                             "properties": {
                                                 "name": {
                                                     "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
@@ -3316,7 +3316,7 @@
                                     "description": "VolumeMount describes a mounting of a Volume within a container.",
                                     "properties": {
                                         "mountPath": {
-                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                            "description": "Path within the container at which the volume should be mounted.",
                                             "type": "string"
                                         },
                                         "mountPropagation": {

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -44,7 +44,6 @@ spec:
             - --secure-proxy=false
           image: ghcr.io/llm-d/llm-d-routing-sidecar:latest
           imagePullPolicy: Always
-          env:
           ports:
             - containerPort: 8000
           resources: {}
@@ -106,7 +105,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-dra.yaml
+++ b/examples/output-dra.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: dra-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: dra-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -116,7 +116,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: intel-gaudi-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-gaudi.yaml
+++ b/examples/output-gaudi.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: gaudi-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: gaudi-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-heterogeneous-pd.yaml
+++ b/examples/output-heterogeneous-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: heterogeneous-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -44,7 +44,6 @@ spec:
             - --secure-proxy=false
           image: ghcr.io/llm-d/llm-d-routing-sidecar:latest
           imagePullPolicy: Always
-          env:
           ports:
             - containerPort: 8000
           resources: {}
@@ -132,7 +131,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -225,7 +224,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: nvidia-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-pd-mnnvl.yaml
+++ b/examples/output-pd-mnnvl.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-mnnvl-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -44,7 +44,6 @@ spec:
             - --secure-proxy=false
           image: ghcr.io/llm-d/llm-d-routing-sidecar:latest
           imagePullPolicy: Always
-          env:
           ports:
             - containerPort: 8000
           resources: {}
@@ -132,7 +131,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -44,7 +44,6 @@ spec:
             - --secure-proxy=false
           image: ghcr.io/llm-d/llm-d-routing-sidecar:latest
           imagePullPolicy: Always
-          env:
           ports:
             - containerPort: 8000
           resources: {}
@@ -128,7 +127,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -44,7 +44,6 @@ spec:
             - --secure-proxy=false
           image: ghcr.io/llm-d/llm-d-routing-sidecar:latest
           imagePullPolicy: Always
-          env:
           ports:
             - containerPort: 8000
           resources: {}
@@ -129,7 +128,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -44,7 +44,6 @@ spec:
             - --secure-proxy=false
           image: ghcr.io/llm-d/llm-d-routing-sidecar:latest
           imagePullPolicy: Always
-          env:
           ports:
             - containerPort: 8000
           resources: {}
@@ -127,7 +126,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-rebellions-atom.yaml
+++ b/examples/output-rebellions-atom.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: rebellions-atom-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: rebellions-atom-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-requester.yaml
+++ b/examples/output-requester.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: requester-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -43,7 +43,6 @@ spec:
                 - --secure-proxy=false
               image: ghcr.io/llm-d/llm-d-routing-sidecar:latest
               imagePullPolicy: Always
-              env:
               ports:
                 - containerPort: 8000
               resources: {}
@@ -143,7 +142,7 @@ kind: Deployment
 metadata:
   name: requester-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu-pd.yaml
+++ b/examples/output-xpu-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -44,7 +44,6 @@ spec:
             - --secure-proxy=false
           image: ghcr.io/llm-d/llm-d-routing-sidecar:latest
           imagePullPolicy: Always
-          env:
           ports:
             - containerPort: 8000
           resources: {}
@@ -159,7 +158,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu.yaml
+++ b/examples/output-xpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Manual testing performed
- [x] `helm template` dry run verified

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`make pre-commit-run`)
- [x] Linters pass (`make lint`)
- [x] Generated examples are in sync (`make verify`)
- [x] Chart version bumped (`make bump-chart-version-{patch|minor|major}`)
- [x] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
