### PR TITLE
fix: do not render replica in prefill and decode if autoscaling is enabled

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "v0.4.12"
+version: "v0.4.13"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/llm-d-modelservice/templates/decode-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/decode-deployment.yaml
@@ -20,7 +20,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  {{- if not .Values.decode.autoscaling.enabled }}
   replicas: {{ ternary .Values.decode.replicas 1 (hasKey .Values.decode "replicas") }}
+  {{- end }}
   {{- if .Values.decode.strategy }}
   strategy:
     {{- toYaml .Values.decode.strategy | nindent 4 }}

--- a/charts/llm-d-modelservice/templates/prefill-deployment.yaml
+++ b/charts/llm-d-modelservice/templates/prefill-deployment.yaml
@@ -20,7 +20,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  {{- if not .Values.prefill.autoscaling.enabled }}
   replicas: {{ ternary .Values.prefill.replicas 1 (hasKey .Values.prefill "replicas") }}
+  {{- end }}
   {{- if .Values.prefill.strategy }}
   strategy:
     {{- toYaml .Values.prefill.strategy | nindent 4 }}

--- a/charts/llm-d-modelservice/values.schema.json
+++ b/charts/llm-d-modelservice/values.schema.json
@@ -1707,7 +1707,7 @@
                                     "description": "VolumeMount describes a mounting of a Volume within a container.",
                                     "properties": {
                                         "mountPath": {
-                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                            "description": "Path within the container at which the volume should be mounted.",
                                             "type": "string"
                                         },
                                         "mountPropagation": {
@@ -3316,7 +3316,7 @@
                                     "description": "VolumeMount describes a mounting of a Volume within a container.",
                                     "properties": {
                                         "mountPath": {
-                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                            "description": "Path within the container at which the volume should be mounted.",
                                             "type": "string"
                                         },
                                         "mountPropagation": {

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-dra.yaml
+++ b/examples/output-dra.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: dra-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: dra-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -116,7 +116,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: intel-gaudi-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-gaudi.yaml
+++ b/examples/output-gaudi.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: gaudi-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: gaudi-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-heterogeneous-pd.yaml
+++ b/examples/output-heterogeneous-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: heterogeneous-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,7 +132,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -225,7 +225,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: nvidia-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-pd-mnnvl.yaml
+++ b/examples/output-pd-mnnvl.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-mnnvl-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,7 +132,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -128,7 +128,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -129,7 +129,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -127,7 +127,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-rebellions-atom.yaml
+++ b/examples/output-rebellions-atom.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: rebellions-atom-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: rebellions-atom-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-requester.yaml
+++ b/examples/output-requester.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: requester-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -143,7 +143,7 @@ kind: Deployment
 metadata:
   name: requester-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu-pd.yaml
+++ b/examples/output-xpu-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -159,7 +159,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu.yaml
+++ b/examples/output-xpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.12
+    helm.sh/chart: llm-d-modelservice-v0.4.13
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:


### PR DESCRIPTION
## What does this PR do?

This skips replicas from being rendered if autoscaling is enabled.

## Why is this change needed?

In cases when an HPA manages the pods, it is important that replicas is not rendered to avoid race conditions.


## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Manual testing performed
- [x] `helm template` dry run verified

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`make pre-commit-run`)
- [x] Linters pass (`make lint`)
- [x] Generated examples are in sync (`make verify`)
- [x] Chart version bumped (`make bump-chart-version-{patch|minor|major}`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #256 