### PR TITLE
chore(chart): pin LWS CRD doc links to v0.9.0 and track upstream version

### DIFF
--- a/charts/llm-d-modelservice/Chart.yaml
+++ b/charts/llm-d-modelservice/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "v0.4.14"
+version: "v0.4.15"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/llm-d-modelservice/values.yaml
+++ b/charts/llm-d-modelservice/values.yaml
@@ -413,12 +413,12 @@ decode:
 
   # hostIPC -- Boolean: Use the host's ipc namespace.
   # -- Not set by default.
-  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12196.
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/v0.9.0/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L4201.
   # hostIPC: false
 
   # hostPID -- Boolean: Use the host's pid namespace.
   # -- Not set by default.
-  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12207.
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/v0.9.0/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L4214.
   # hostPID: false
 
   # enableServiceLinks -- Boolean: Indicates whether information about services should be injected into pod's environment variables.
@@ -431,7 +431,7 @@ decode:
 
   # subGroupPolicy -- object: SubGroupPolicy describes the policy that will be applied when creating subgroups in each replica.
   # -- Not set by default
-  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L8207
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/v0.9.0/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L8673
   # subGroupPolicy:
   #   subGroupSize: 8
 
@@ -635,12 +635,12 @@ prefill:
 
   # hostIPC -- Boolean: Use the host's ipc namespace.
   # -- Not set by default.
-  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12196.
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/v0.9.0/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L4201.
   # hostIPC: false
 
   # hostPID -- Boolean: Use the host's pid namespace.
   # -- Not set by default.
-  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L12207.
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/v0.9.0/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L4214.
   # hostPID: false
 
   # enableServiceLinks -- Boolean: Indicates whether information about services should be injected into pod's environment variables.
@@ -653,7 +653,7 @@ prefill:
 
   # subGroupPolicy -- object: SubGroupPolicy describes the policy that will be applied when creating subgroups in each replica.
   # -- Not set by default
-  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L8207
+  # -- Only an option for LWS (multinode) See: https://github.com/kubernetes-sigs/lws/blob/v0.9.0/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L8673
   # subGroupPolicy:
   #   subGroupSize: 8
 

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -5,8 +5,6 @@
 
 ## Dependencies
 
-<!-- Add your tracked dependencies using the format below. Remove this comment when populated. -->
-
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |-----------|-------------|----------|---------------|---------------|
-<!-- | **example-lib** | `v1.2.3` | tag | `go.mod` line 10 | example-org/example-lib | -->
+| **LeaderWorkerSet (LWS)** | `v0.9.0` | tag | CRD doc links in `charts/llm-d-modelservice/values.yaml`; CRD `apiVersion: leaderworkerset.x-k8s.io/v1` in `templates/{decode,prefill}-lws.yaml` | kubernetes-sigs/lws |

--- a/examples/output-cpu.yaml
+++ b/examples/output-cpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: cpu-sim-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -105,7 +105,7 @@ kind: Deployment
 metadata:
   name: cpu-sim-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-dra.yaml
+++ b/examples/output-dra.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: dra-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: dra-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -116,7 +116,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: intel-gaudi-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-gaudi.yaml
+++ b/examples/output-gaudi.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: gaudi-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: gaudi-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-heterogeneous-pd.yaml
+++ b/examples/output-heterogeneous-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: heterogeneous-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -131,7 +131,7 @@ kind: Deployment
 metadata:
   name: heterogeneous-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -224,7 +224,7 @@ kind: ResourceClaimTemplate
 metadata:
   name: nvidia-claim-template-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
     llm-d.ai/role: decode

--- a/examples/output-pd-mnnvl.yaml
+++ b/examples/output-pd-mnnvl.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-mnnvl-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -131,7 +131,7 @@ kind: Deployment
 metadata:
   name: pd-mnnvl-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pd.yaml
+++ b/examples/output-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -127,7 +127,7 @@ kind: Deployment
 metadata:
   name: pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc-hf.yaml
+++ b/examples/output-pvc-hf.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-hf-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -128,7 +128,7 @@ kind: Deployment
 metadata:
   name: pvc-hf-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-pvc.yaml
+++ b/examples/output-pvc.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: pvc-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -126,7 +126,7 @@ kind: Deployment
 metadata:
   name: pvc-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-rebellions-atom.yaml
+++ b/examples/output-rebellions-atom.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: rebellions-atom-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: rebellions-atom-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-requester.yaml
+++ b/examples/output-requester.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: requester-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -142,7 +142,7 @@ kind: Deployment
 metadata:
   name: requester-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu-pd.yaml
+++ b/examples/output-xpu-pd.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-pd-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -158,7 +158,7 @@ kind: Deployment
 metadata:
   name: xpu-pd-llm-d-modelservice-prefill
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/examples/output-xpu.yaml
+++ b/examples/output-xpu.yaml
@@ -6,7 +6,7 @@ kind: ServiceAccount
 metadata:
   name: xpu-llm-d-modelservice
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -16,7 +16,7 @@ kind: Deployment
 metadata:
   name: xpu-llm-d-modelservice-decode
   labels:
-    helm.sh/chart: llm-d-modelservice-v0.4.14
+    helm.sh/chart: llm-d-modelservice-v0.4.15
     app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:


### PR DESCRIPTION
## What does this PR do?

[LeaderWorkerSet (LWS) v0.9.0](https://github.com/kubernetes-sigs/lws/releases/tag/v0.9.0) was released, so this PR points the chart's LWS references at that tagged release instead of the moving `main` branch.

- **`charts/llm-d-modelservice/values.yaml`**: pin the 6 LWS CRD reference links from `blob/main/` to `blob/v0.9.0/`, and fix the stale line anchors. The old `#L12196` / `#L12207` / `#L8207` anchors had drifted on `main` and no longer pointed at `hostIPC` / `hostPID` / `subGroupPolicy`; the corrected v0.9.0 anchors are `#L4201` / `#L4214` / `#L8673`.
- **`docs/upstream-versions.md`**: register LWS `v0.9.0` as a tracked upstream dependency (the file was previously an empty template).
- **`charts/llm-d-modelservice/Chart.yaml`**: bump chart version `v0.4.14` → `v0.4.15` (required by `ct lint` for any `charts/` change) and regenerate the example outputs accordingly.

## Why is this change needed?

The LWS v0.9.0 release ([kubernetes-sigs/lws#884](https://github.com/kubernetes-sigs/lws/issues/884)) was cut specifically so downstream projects can pin an official version instead of a `main` hash. Pinning to the tag makes the doc links stable and version-accurate; as a side effect it also fixes anchors that had already drifted on `main`.

## How was this tested?

- [x] Manual testing performed
- [x] `helm template` dry run verified

Local checks (mirroring CI):

- `ct lint --target-branch main` → `All charts linted successfully` (chart version bump detected, schema validation passed)
- `make verify` → regenerated examples match (only the embedded `helm.sh/chart` version string changed)
- `helm lint` → pass (only the informational `icon is recommended` notice)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](../PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`make pre-commit-run`)
- [x] Linters pass (`make lint`)
- [x] Generated examples are in sync (`make verify`)
- [x] Chart version bumped (`make bump-chart-version-{patch|minor|major}`)
- [x] Documentation updated (if applicable)

## Related Issues

Related to #252 (DisaggregatedSet adoption — not implemented here; this PR only pins the existing LWS references).